### PR TITLE
Add dependency review workflow and enhance Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,26 @@
 version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+updates:
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          deny-licenses: GPL-3.0, AGPL-3.0


### PR DESCRIPTION
## Summary
- **Dependency review workflow**: Blocks PRs that introduce dependencies with high-severity vulnerabilities or GPL-3.0/AGPL-3.0 licenses
- **Enhanced Dependabot config**: Groups minor+patch npm updates together, pins schedule to Mondays, adds labels for easier triage

## Repo settings also updated (outside this PR)
- Ruleset "Protect main" created: requires PR, CI pass, linear history, blocks force push/deletion
- Required status checks: `ci` + `dependency-review` (must be up-to-date with main)
- Squash merge commit title now uses PR title
- Secret scanning + push protection enabled
- Dependabot alerts enabled
- Private vulnerability reporting enabled
- Discussions enabled

## Test plan
- [ ] Verify dependency-review workflow runs on this PR
- [ ] Verify CI still passes
- [ ] Confirm ruleset is active at Settings > Rules > Rulesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)