### PR TITLE
Add TanStack Query provider and API client foundation

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -2,6 +2,20 @@ import { test, expect } from './fixtures'
 import { navigateAndWait } from './helpers/navigation'
 
 test.describe('Smoke tests', () => {
+  test('no console errors on page load', async ({ page }) => {
+    const errors: string[] = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text())
+      }
+    })
+
+    await navigateAndWait(page, '/')
+    await expect(page).toHaveURL(/\/reports/)
+
+    expect(errors).toEqual([])
+  })
+
   test('/ redirects to /reports', async ({ page }) => {
     await navigateAndWait(page, '/')
     await expect(page).toHaveURL(/\/reports/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@chakra-ui/react": "^3.33.0",
         "@emotion/react": "^11.14.0",
+        "@tanstack/react-query": "^5.90.21",
+        "@tanstack/react-query-devtools": "^5.91.3",
         "next": "^16.1.6",
         "next-themes": "^0.4.4",
         "react": "^19.2.0",
@@ -2618,6 +2620,59 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.93.0.tgz",
+      "integrity": "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.91.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.3.tgz",
+      "integrity": "sha512-nlahjMtd/J1h7IzOOfqeyDh5LNfG0eULwlltPEonYy0QL+nqrBB+nyzJfULV+moL7sZyxc2sHdNJki+vLA9BSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.93.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.20",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@chakra-ui/react": "^3.33.0",
     "@emotion/react": "^11.14.0",
+    "@tanstack/react-query": "^5.90.21",
+    "@tanstack/react-query-devtools": "^5.91.3",
     "next": "^16.1.6",
     "next-themes": "^0.4.4",
     "react": "^19.2.0",

--- a/src/app/providers.test.tsx
+++ b/src/app/providers.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { screen } from '@testing-library/react'
+import { useQueryClient } from '@tanstack/react-query'
 import { render } from '@/test/render'
 import { Providers } from './providers'
 
@@ -36,5 +37,20 @@ describe('Providers', () => {
 
     expect(screen.getByText('first')).toBeInTheDocument()
     expect(screen.getByText('second')).toBeInTheDocument()
+  })
+
+  it('provides QueryClient context to children', () => {
+    function QueryClientConsumer() {
+      const client = useQueryClient()
+      return <p data-testid="qc">{client ? 'has-client' : 'no-client'}</p>
+    }
+
+    render(
+      <Providers>
+        <QueryClientConsumer />
+      </Providers>,
+    )
+
+    expect(screen.getByTestId('qc')).toHaveTextContent('has-client')
   })
 })

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,15 +1,24 @@
 'use client'
 
+import { useState } from 'react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { ChakraProvider } from '@chakra-ui/react'
 import { ThemeProvider } from 'next-themes'
 import { system } from '@/theme'
+import { createAppQueryClient } from '@/lib/api/query-client'
 
 export function Providers({ children }: Readonly<{ children: React.ReactNode }>) {
+  const [queryClient] = useState(() => createAppQueryClient())
+
   return (
-    <ChakraProvider value={system}>
-      <ThemeProvider attribute="class" disableTransitionOnChange>
-        {children}
-      </ThemeProvider>
-    </ChakraProvider>
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider value={system}>
+        <ThemeProvider attribute="class" disableTransitionOnChange>
+          {children}
+        </ThemeProvider>
+      </ChakraProvider>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   )
 }

--- a/src/lib/api/client.test.ts
+++ b/src/lib/api/client.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { apiFetch, ApiError, clearEtagCache } from './client'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  clearEtagCache()
+})
+
+describe('apiFetch', () => {
+  it('fetches JSON successfully', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ id: 1, name: 'test' }))
+
+    const result = await apiFetch<{ id: number; name: string }>('/v1/reports')
+
+    expect(result).toEqual({ id: 1, name: 'test' })
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/reports',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+      }),
+    )
+  })
+
+  it('uses NEXT_PUBLIC_API_URL when set', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.example.com')
+    mockFetch.mockResolvedValue(jsonResponse({ ok: true }))
+
+    await apiFetch('/v1/test')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example.com/v1/test',
+      expect.any(Object),
+    )
+    vi.unstubAllEnvs()
+  })
+
+  it('sends JSON body', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ created: true }))
+
+    await apiFetch('/v1/reports', {
+      method: 'POST',
+      body: { title: 'Report' },
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/reports',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ title: 'Report' }),
+      }),
+    )
+  })
+
+  it('throws ApiError on 401', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: 'Unauthorized', code: 'AUTH_REQUIRED' }, 401),
+    )
+
+    const error = await apiFetch('/v1/reports').catch((e) => e)
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error).toMatchObject({
+      status: 401,
+      message: 'Unauthorized',
+      code: 'AUTH_REQUIRED',
+    })
+  })
+
+  it('throws ApiError on 403', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: 'Forbidden' }, 403),
+    )
+
+    const error = await apiFetch('/v1/reports').catch((e) => e)
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error).toMatchObject({ status: 403, message: 'Forbidden' })
+  })
+
+  it('throws ApiError on 404', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: 'Not found' }, 404),
+    )
+
+    const error = await apiFetch('/v1/reports/999').catch((e) => e)
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error).toMatchObject({ status: 404, message: 'Not found' })
+  })
+
+  it('throws ApiError on 500', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: 'Internal server error' }, 500),
+    )
+
+    const error = await apiFetch('/v1/reports').catch((e) => e)
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error).toMatchObject({ status: 500, message: 'Internal server error' })
+  })
+
+  it('falls back to statusText when error body has no message field', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ error: 'something' }, 422),
+    )
+
+    const error = await apiFetch('/v1/reports').catch((e) => e)
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error).toMatchObject({ status: 422, message: 'Error' })
+  })
+
+  it('throws ApiError with statusText when body is not JSON', async () => {
+    mockFetch.mockResolvedValue(
+      new Response('Not Found', { status: 404, statusText: 'Not Found' }),
+    )
+
+    await expect(apiFetch('/v1/missing')).rejects.toMatchObject({
+      status: 404,
+      message: 'Not Found',
+    })
+  })
+
+  it('throws ApiError on network error', async () => {
+    mockFetch.mockRejectedValue(new TypeError('Failed to fetch'))
+
+    await expect(apiFetch('/v1/reports')).rejects.toThrow(ApiError)
+    await expect(apiFetch('/v1/reports')).rejects.toMatchObject({
+      status: 0,
+      message: 'Network error',
+    })
+  })
+
+  it('stores and sends ETags for cached responses', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ items: [1] }, 200, { ETag: '"abc123"' }),
+    )
+
+    const first = await apiFetch('/v1/reports')
+    expect(first).toEqual({ items: [1] })
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, { status: 304, statusText: 'Not Modified' }),
+    )
+
+    const second = await apiFetch('/v1/reports')
+    expect(second).toEqual({ items: [1] })
+
+    const secondCallInit = mockFetch.mock.calls[1][1]
+    expect(secondCallInit.headers['If-None-Match']).toBe('"abc123"')
+  })
+
+  it('does not send ETag for non-GET requests', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ items: [1] }, 200, { ETag: '"abc123"' }),
+    )
+    await apiFetch('/v1/reports')
+
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }))
+    await apiFetch('/v1/reports', { method: 'POST', body: {} })
+
+    const secondCallInit = mockFetch.mock.calls[1][1]
+    expect(secondCallInit.headers['If-None-Match']).toBeUndefined()
+  })
+
+  it('calls onRequest interceptor', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ ok: true }))
+
+    const onRequest = vi.fn((_url: string, init: RequestInit) => ({
+      ...init,
+      headers: { ...init.headers, 'X-Custom': 'value' },
+    }))
+
+    await apiFetch('/v1/test', { onRequest })
+
+    expect(onRequest).toHaveBeenCalledOnce()
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/test',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Custom': 'value' }),
+      }),
+    )
+  })
+
+  it('calls onResponse interceptor', async () => {
+    const res = jsonResponse({ ok: true })
+    mockFetch.mockResolvedValue(res)
+
+    const onResponse = vi.fn()
+    await apiFetch('/v1/test', { onResponse })
+
+    expect(onResponse).toHaveBeenCalledWith(res)
+  })
+})

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,94 @@
+const etagCache = new Map<string, { etag: string; data: unknown }>()
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly code?: string,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+export interface ApiFetchOptions extends Omit<RequestInit, 'body'> {
+  body?: unknown
+  onRequest?: (url: string, init: RequestInit) => RequestInit
+  onResponse?: (response: Response) => void
+}
+
+export async function apiFetch<T>(
+  path: string,
+  options: ApiFetchOptions = {},
+): Promise<T> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? '/api'
+  const url = `${baseUrl}${path}`
+
+  const { body, onRequest, onResponse, ...init } = options
+
+  let requestInit: RequestInit = {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+  }
+
+  if (body !== undefined) {
+    requestInit.body = JSON.stringify(body)
+  }
+
+  const cached = etagCache.get(url)
+  if (cached && requestInit.method === undefined) {
+    requestInit.headers = {
+      ...requestInit.headers,
+      'If-None-Match': cached.etag,
+    }
+  }
+
+  if (onRequest) {
+    requestInit = onRequest(url, requestInit)
+  }
+
+  let response: Response
+  try {
+    response = await fetch(url, requestInit)
+  } catch {
+    throw new ApiError(0, 'Network error')
+  }
+
+  if (onResponse) {
+    onResponse(response)
+  }
+
+  if (response.status === 304 && cached) {
+    return cached.data as T
+  }
+
+  if (!response.ok) {
+    let message = response.statusText
+    let code: string | undefined
+    try {
+      const errorBody = await response.json()
+      message = errorBody.message ?? message
+      code = errorBody.code
+    } catch {
+      // use statusText
+    }
+    throw new ApiError(response.status, message, code)
+  }
+
+  const data: T = await response.json()
+
+  const etag = response.headers.get('ETag')
+  if (etag) {
+    etagCache.set(url, { etag, data })
+  }
+
+  return data
+}
+
+/** Clear the ETag cache — useful in tests */
+export function clearEtagCache() {
+  etagCache.clear()
+}

--- a/src/lib/api/query-client.ts
+++ b/src/lib/api/query-client.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export function createAppQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+      mutations: {
+        retry: 0,
+      },
+    },
+  })
+}

--- a/src/lib/api/query-keys.test.ts
+++ b/src/lib/api/query-keys.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { queryKeys } from './query-keys'
+
+describe('queryKeys', () => {
+  describe('reports', () => {
+    it('has correct base key', () => {
+      expect(queryKeys.reports.all).toEqual(['reports'])
+    })
+
+    it('produces list key without params', () => {
+      expect(queryKeys.reports.list()).toEqual(['reports', 'list', undefined])
+    })
+
+    it('produces list key with params', () => {
+      const params = { page: 1, pageSize: 10 }
+      expect(queryKeys.reports.list(params)).toEqual(['reports', 'list', params])
+    })
+
+    it('produces different keys for different params', () => {
+      const a = queryKeys.reports.list({ page: 1 })
+      const b = queryKeys.reports.list({ page: 2 })
+      expect(a).not.toEqual(b)
+    })
+
+    it('produces detail key', () => {
+      expect(queryKeys.reports.detail('abc')).toEqual(['reports', 'detail', 'abc'])
+    })
+  })
+
+  describe('profile', () => {
+    it('has correct base key', () => {
+      expect(queryKeys.profile.all).toEqual(['profile'])
+    })
+
+    it('produces me key', () => {
+      expect(queryKeys.profile.me()).toEqual(['profile', 'me'])
+    })
+  })
+
+  describe('accessGrants', () => {
+    it('has correct base key', () => {
+      expect(queryKeys.accessGrants.all).toEqual(['accessGrants'])
+    })
+
+    it('produces list key', () => {
+      expect(queryKeys.accessGrants.list()).toEqual(['accessGrants', 'list'])
+    })
+
+    it('produces detail key', () => {
+      expect(queryKeys.accessGrants.detail('x')).toEqual(['accessGrants', 'detail', 'x'])
+    })
+  })
+
+  describe('consents', () => {
+    it('has correct base key', () => {
+      expect(queryKeys.consents.all).toEqual(['consents'])
+    })
+
+    it('produces list key', () => {
+      expect(queryKeys.consents.list()).toEqual(['consents', 'list'])
+    })
+
+    it('produces detail key', () => {
+      expect(queryKeys.consents.detail('y')).toEqual(['consents', 'detail', 'y'])
+    })
+  })
+})

--- a/src/lib/api/query-keys.ts
+++ b/src/lib/api/query-keys.ts
@@ -1,0 +1,32 @@
+export interface ReportListParams {
+  page?: number
+  pageSize?: number
+  search?: string
+  category?: string
+}
+
+export const queryKeys = {
+  reports: {
+    all: ['reports'] as const,
+    list: (params?: ReportListParams) =>
+      [...queryKeys.reports.all, 'list', params] as const,
+    detail: (id: string) =>
+      [...queryKeys.reports.all, 'detail', id] as const,
+  },
+  profile: {
+    all: ['profile'] as const,
+    me: () => [...queryKeys.profile.all, 'me'] as const,
+  },
+  accessGrants: {
+    all: ['accessGrants'] as const,
+    list: () => [...queryKeys.accessGrants.all, 'list'] as const,
+    detail: (id: string) =>
+      [...queryKeys.accessGrants.all, 'detail', id] as const,
+  },
+  consents: {
+    all: ['consents'] as const,
+    list: () => [...queryKeys.consents.all, 'list'] as const,
+    detail: (id: string) =>
+      [...queryKeys.consents.all, 'detail', id] as const,
+  },
+}

--- a/src/lib/api/stale-times.test.ts
+++ b/src/lib/api/stale-times.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { staleTimes } from './stale-times'
+
+describe('staleTimes', () => {
+  it('reports stale time is 2 minutes', () => {
+    expect(staleTimes.reports).toBe(120_000)
+  })
+
+  it('profile stale time is 10 minutes', () => {
+    expect(staleTimes.profile).toBe(600_000)
+  })
+
+  it('accessGrants stale time is 1 minute', () => {
+    expect(staleTimes.accessGrants).toBe(60_000)
+  })
+
+  it('consents stale time is 30 seconds', () => {
+    expect(staleTimes.consents).toBe(30_000)
+  })
+})

--- a/src/lib/api/stale-times.ts
+++ b/src/lib/api/stale-times.ts
@@ -1,0 +1,6 @@
+export const staleTimes = {
+  reports: 2 * 60 * 1000, // 2 min
+  profile: 10 * 60 * 1000, // 10 min
+  accessGrants: 1 * 60 * 1000, // 1 min
+  consents: 30 * 1000, // 30 sec
+}

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -1,16 +1,35 @@
 import { render, type RenderOptions } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ChakraProvider } from '@chakra-ui/react'
 import { ThemeProvider } from 'next-themes'
 import { system } from '@/theme'
 
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+}
+
 function AllProviders({ children }: Readonly<{ children: React.ReactNode }>) {
+  const queryClient = createTestQueryClient()
+
   return (
-    <ChakraProvider value={system}>
-      <ThemeProvider attribute="class" disableTransitionOnChange>
-        {children}
-      </ThemeProvider>
-    </ChakraProvider>
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider value={system}>
+        <ThemeProvider attribute="class" disableTransitionOnChange>
+          {children}
+        </ThemeProvider>
+      </ChakraProvider>
+    </QueryClientProvider>
   )
 }
 


### PR DESCRIPTION
## Summary
- Install `@tanstack/react-query` and `@tanstack/react-query-devtools` v5
- Add `apiFetch<T>()` wrapper with ETag caching, standardized `ApiError` class, and request/response interceptors (`src/lib/api/client.ts`)
- Add type-safe query key factory for reports, profile, accessGrants, and consents (`src/lib/api/query-keys.ts`)
- Add named stale time constants per architecture spec (`src/lib/api/stale-times.ts`)
- Add `createAppQueryClient()` factory with default retry/refetch settings (`src/lib/api/query-client.ts`)
- Wire `QueryClientProvider` + `ReactQueryDevtools` into app providers and test render helper
- Add E2E smoke test for console errors on page load

## Test plan
- [x] `npm run lint` — no errors
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run test:coverage` — 71 tests pass, 100% line coverage
- [x] `npm run build` — successful production build
- [x] `npx playwright test --project=chromium` — 8 E2E tests pass (including new console errors check)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)