### PR TITLE
Add portal shell layout (sidebar, top bar, mobile bottom nav)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -19,7 +19,7 @@ test.describe('Smoke tests', () => {
   test('/ redirects to /reports', async ({ page }) => {
     await navigateAndWait(page, '/')
     await expect(page).toHaveURL(/\/reports/)
-    await expect(page.getByText('Reports')).toBeVisible()
+    await expect(page.getByRole('main').getByText('Reports')).toBeVisible()
   })
 
   test('/login loads and contains "Login"', async ({ page }) => {
@@ -38,23 +38,37 @@ test.describe('Smoke tests', () => {
 
   test('/reports loads and contains "Reports"', async ({ page }) => {
     await navigateAndWait(page, '/reports')
-    await expect(page.getByText('Reports')).toBeVisible()
+    await expect(page.getByRole('main').getByText('Reports')).toBeVisible()
   })
 
   test('/access loads and contains "Access Grants"', async ({ page }) => {
     await navigateAndWait(page, '/access')
-    await expect(page.getByText('Access Grants')).toBeVisible()
+    await expect(page.getByRole('main').getByText('Access Grants')).toBeVisible()
   })
 
   test('/emergency loads and contains "Emergency Contacts"', async ({
     page,
   }) => {
     await navigateAndWait(page, '/emergency')
-    await expect(page.getByText('Emergency Contacts')).toBeVisible()
+    await expect(page.getByRole('main').getByText('Emergency Contacts')).toBeVisible()
   })
 
   test('/settings loads and contains "Settings"', async ({ page }) => {
     await navigateAndWait(page, '/settings')
-    await expect(page.getByText('Settings')).toBeVisible()
+    await expect(page.getByRole('main').getByText('Settings')).toBeVisible()
+  })
+
+  test('sidebar navigation works between portal routes', async ({ page }) => {
+    await navigateAndWait(page, '/reports')
+    await expect(page.getByRole('main').getByText('Reports')).toBeVisible()
+
+    const sidebar = page.getByRole('navigation', { name: /main navigation/i })
+    await sidebar.getByRole('link', { name: /access/i }).click()
+    await page.waitForURL(/\/access/)
+    await expect(page.getByRole('main').getByText('Access Grants')).toBeVisible()
+
+    await sidebar.getByRole('link', { name: /settings/i }).click()
+    await page.waitForURL(/\/settings/)
+    await expect(page.getByRole('main').getByText('Settings')).toBeVisible()
   })
 })

--- a/src/app/(portal)/layout.test.tsx
+++ b/src/app/(portal)/layout.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, userEvent } from '@/test/render'
+import PortalLayout from './layout'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/reports',
+}))
+
+vi.mock('next-themes', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+  useTheme: () => ({
+    resolvedTheme: 'light',
+    setTheme: vi.fn(),
+  }),
+}))
+
+describe('PortalLayout', () => {
+  it('renders children', () => {
+    render(
+      <PortalLayout>
+        <div>Test Content</div>
+      </PortalLayout>
+    )
+    expect(screen.getByText('Test Content')).toBeInTheDocument()
+  })
+
+  it('renders the top bar with Aarogya branding', () => {
+    render(
+      <PortalLayout>
+        <div>Content</div>
+      </PortalLayout>
+    )
+    expect(screen.getByText('Aarogya')).toBeInTheDocument()
+  })
+
+  it('renders the sidebar navigation', () => {
+    const { container } = render(
+      <PortalLayout>
+        <div>Content</div>
+      </PortalLayout>
+    )
+    // Sidebar uses display={{ base: 'none', md: 'flex' }}, hidden in jsdom (no media queries)
+    const nav = container.querySelector('nav[aria-label="Main navigation"]')
+    expect(nav).toBeInTheDocument()
+  })
+
+  it('renders the bottom navigation', () => {
+    render(
+      <PortalLayout>
+        <div>Content</div>
+      </PortalLayout>
+    )
+    expect(screen.getByRole('navigation', { name: /mobile navigation/i })).toBeInTheDocument()
+  })
+
+  it('renders a main content area', () => {
+    render(
+      <PortalLayout>
+        <div>Content</div>
+      </PortalLayout>
+    )
+    expect(screen.getByRole('main')).toBeInTheDocument()
+  })
+
+  it('toggles sidebar collapse via top bar menu button', async () => {
+    const user = userEvent.setup()
+    render(
+      <PortalLayout>
+        <div>Content</div>
+      </PortalLayout>
+    )
+
+    // Click the mobile menu toggle to trigger setCollapsed
+    await user.click(screen.getByRole('button', { name: /toggle menu/i }))
+    // After toggling, the sidebar collapse button should say "Expand"
+    expect(screen.getByRole('button', { name: /expand sidebar/i, hidden: true })).toBeInTheDocument()
+  })
+
+  it('toggles sidebar collapse via sidebar chevron', async () => {
+    const user = userEvent.setup()
+    render(
+      <PortalLayout>
+        <div>Content</div>
+      </PortalLayout>
+    )
+
+    // Click the sidebar collapse button
+    await user.click(screen.getByRole('button', { name: /collapse sidebar/i, hidden: true }))
+    expect(screen.getByRole('button', { name: /expand sidebar/i, hidden: true })).toBeInTheDocument()
+  })
+})

--- a/src/app/(portal)/layout.tsx
+++ b/src/app/(portal)/layout.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useState } from 'react'
+import { Box } from '@chakra-ui/react'
+import { TopBar } from '@/components/portal/top-bar'
+import { Sidebar, SIDEBAR_EXPANDED, SIDEBAR_COLLAPSED } from '@/components/portal/sidebar'
+import { BottomNav } from '@/components/portal/bottom-nav'
+
+export default function PortalLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  const [collapsed, setCollapsed] = useState(false)
+  const sidebarWidth = collapsed ? SIDEBAR_COLLAPSED : SIDEBAR_EXPANDED
+
+  return (
+    <>
+      <TopBar onMenuToggle={() => setCollapsed((c) => !c)} />
+      <Sidebar collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
+      <Box
+        as="main"
+        ml={{ base: 0, md: `${sidebarWidth}px` }}
+        pt="56px"
+        pb={{ base: '80px', md: 0 }}
+        p={{ base: 4, md: 6 }}
+        transition="margin-left 0.2s cubic-bezier(0.4,0,0.2,1)"
+        minHeight="100vh"
+      >
+        {children}
+      </Box>
+      <BottomNav />
+    </>
+  )
+}

--- a/src/components/portal/bottom-nav.test.tsx
+++ b/src/components/portal/bottom-nav.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@/test/render'
+import { BottomNav } from './bottom-nav'
+
+let mockPathname = '/reports'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}))
+
+vi.mock('next-themes', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+  useTheme: () => ({
+    resolvedTheme: 'light',
+    setTheme: vi.fn(),
+  }),
+}))
+
+describe('BottomNav', () => {
+  beforeEach(() => {
+    mockPathname = '/reports'
+  })
+
+  it('renders all four navigation items', () => {
+    render(<BottomNav />)
+    expect(screen.getByText('Reports')).toBeInTheDocument()
+    expect(screen.getByText('Access')).toBeInTheDocument()
+    expect(screen.getByText('Emergency')).toBeInTheDocument()
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+
+  it('renders nav links with correct hrefs', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('link', { name: /reports/i })).toHaveAttribute('href', '/reports')
+    expect(screen.getByRole('link', { name: /access/i })).toHaveAttribute('href', '/access')
+    expect(screen.getByRole('link', { name: /emergency/i })).toHaveAttribute('href', '/emergency')
+    expect(screen.getByRole('link', { name: /settings/i })).toHaveAttribute('href', '/settings')
+  })
+
+  it('has mobile navigation landmark', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('navigation', { name: /mobile navigation/i })).toBeInTheDocument()
+  })
+})

--- a/src/components/portal/bottom-nav.tsx
+++ b/src/components/portal/bottom-nav.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { Box, Flex } from '@chakra-ui/react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { navItems } from './nav-items'
+
+export function BottomNav() {
+  const pathname = usePathname()
+
+  return (
+    <Flex
+      as="nav"
+      aria-label="Mobile navigation"
+      position="fixed"
+      bottom="0"
+      left="0"
+      right="0"
+      zIndex="100"
+      display={{ base: 'flex', md: 'none' }}
+      mx="2"
+      mb="2"
+      px="2"
+      py="1.5"
+      bg="bg.glass"
+      backdropFilter="blur(24px)"
+      border="1px solid"
+      borderColor="border.subtle"
+      borderRadius="xl"
+      justifyContent="space-around"
+      alignItems="center"
+    >
+      {navItems.map((item) => {
+        const isActive = pathname.startsWith(item.href)
+        const Icon = item.icon
+
+        return (
+          <Flex
+            key={item.href}
+            asChild
+            direction="column"
+            alignItems="center"
+            gap="0.5"
+            px="3"
+            py="1.5"
+            borderRadius="lg"
+            textDecoration="none"
+            bg={isActive ? 'bg.card' : 'transparent'}
+            color={isActive ? 'action.primary' : 'text.muted'}
+            _hover={{ color: isActive ? 'action.primary' : 'text.secondary' }}
+            transition="all 0.15s ease"
+          >
+            <Link href={item.href}>
+              <Icon />
+              <Box
+                as="span"
+                fontSize="2xs"
+                fontFamily="mono"
+                letterSpacing="0.04em"
+              >
+                {item.label}
+              </Box>
+            </Link>
+          </Flex>
+        )
+      })}
+    </Flex>
+  )
+}

--- a/src/components/portal/nav-items.tsx
+++ b/src/components/portal/nav-items.tsx
@@ -1,0 +1,116 @@
+import type { ComponentType, SVGProps } from 'react'
+
+type IconProps = SVGProps<SVGSVGElement>
+
+function ReportsIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"
+      viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" {...props}>
+      <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+      <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+      <path d="M10 13H8" />
+      <path d="M16 17H8" />
+      <path d="M16 13h-2" />
+    </svg>
+  )
+}
+
+function AccessIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"
+      viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" {...props}>
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  )
+}
+
+function EmergencyIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"
+      viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" {...props}>
+      <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92Z" />
+    </svg>
+  )
+}
+
+function SettingsIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"
+      viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" {...props}>
+      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  )
+}
+
+export interface NavItem {
+  label: string
+  href: string
+  icon: ComponentType<IconProps>
+}
+
+export const navItems: NavItem[] = [
+  { label: 'Reports', href: '/reports', icon: ReportsIcon },
+  { label: 'Access', href: '/access', icon: AccessIcon },
+  { label: 'Emergency', href: '/emergency', icon: EmergencyIcon },
+  { label: 'Settings', href: '/settings', icon: SettingsIcon },
+]
+
+export function BellIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
+      viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" {...props}>
+      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+    </svg>
+  )
+}
+
+export function MenuIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
+      viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" {...props}>
+      <line x1="4" x2="20" y1="12" y2="12" />
+      <line x1="4" x2="20" y1="6" y2="6" />
+      <line x1="4" x2="20" y1="18" y2="18" />
+    </svg>
+  )
+}
+
+export function ChevronLeftIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
+      viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" {...props}>
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  )
+}
+
+export function UserIcon(props: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
+      viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" {...props}>
+      <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </svg>
+  )
+}

--- a/src/components/portal/sidebar.test.tsx
+++ b/src/components/portal/sidebar.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, userEvent } from '@/test/render'
+import { Sidebar } from './sidebar'
+
+let mockPathname = '/reports'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}))
+
+vi.mock('next-themes', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+  useTheme: () => ({
+    resolvedTheme: 'light',
+    setTheme: vi.fn(),
+  }),
+}))
+
+// The sidebar uses display={{ base: 'none', md: 'flex' }} which jsdom
+// renders as hidden (no media query support). Use { hidden: true } for role queries.
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    mockPathname = '/reports'
+  })
+
+  it('renders all four navigation links', () => {
+    render(<Sidebar collapsed={false} onToggle={vi.fn()} />)
+    expect(screen.getByText('Reports')).toBeInTheDocument()
+    expect(screen.getByText('Access')).toBeInTheDocument()
+    expect(screen.getByText('Emergency')).toBeInTheDocument()
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+
+  it('renders nav links with correct hrefs', () => {
+    render(<Sidebar collapsed={false} onToggle={vi.fn()} />)
+    expect(screen.getByRole('link', { name: /reports/i, hidden: true })).toHaveAttribute('href', '/reports')
+    expect(screen.getByRole('link', { name: /access/i, hidden: true })).toHaveAttribute('href', '/access')
+    expect(screen.getByRole('link', { name: /emergency/i, hidden: true })).toHaveAttribute('href', '/emergency')
+    expect(screen.getByRole('link', { name: /settings/i, hidden: true })).toHaveAttribute('href', '/settings')
+  })
+
+  it('hides labels when collapsed', () => {
+    render(<Sidebar collapsed={true} onToggle={vi.fn()} />)
+    expect(screen.queryByText('Reports')).not.toBeInTheDocument()
+    expect(screen.queryByText('Access')).not.toBeInTheDocument()
+  })
+
+  it('renders collapse toggle button', () => {
+    render(<Sidebar collapsed={false} onToggle={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /collapse sidebar/i, hidden: true })).toBeInTheDocument()
+  })
+
+  it('renders expand button when collapsed', () => {
+    render(<Sidebar collapsed={true} onToggle={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /expand sidebar/i, hidden: true })).toBeInTheDocument()
+  })
+
+  it('calls onToggle when collapse button is clicked', async () => {
+    const onToggle = vi.fn()
+    const user = userEvent.setup()
+    render(<Sidebar collapsed={false} onToggle={onToggle} />)
+
+    await user.click(screen.getByRole('button', { name: /collapse sidebar/i, hidden: true }))
+    expect(onToggle).toHaveBeenCalledOnce()
+  })
+
+  it('has main navigation landmark', () => {
+    const { container } = render(<Sidebar collapsed={false} onToggle={vi.fn()} />)
+    const nav = container.querySelector('nav[aria-label="Main navigation"]')
+    expect(nav).toBeInTheDocument()
+  })
+})

--- a/src/components/portal/sidebar.tsx
+++ b/src/components/portal/sidebar.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { Box, Flex, IconButton } from '@chakra-ui/react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { navItems, ChevronLeftIcon } from './nav-items'
+
+const SIDEBAR_EXPANDED = 240
+const SIDEBAR_COLLAPSED = 72
+
+interface SidebarProps {
+  collapsed: boolean
+  onToggle: () => void
+}
+
+export { SIDEBAR_EXPANDED, SIDEBAR_COLLAPSED }
+
+export function Sidebar({ collapsed, onToggle }: SidebarProps) {
+  const pathname = usePathname()
+  const width = collapsed ? SIDEBAR_COLLAPSED : SIDEBAR_EXPANDED
+
+  return (
+    <Flex
+      as="nav"
+      aria-label="Main navigation"
+      position="fixed"
+      top="56px"
+      left="0"
+      bottom="0"
+      width={`${width}px`}
+      direction="column"
+      bg="bg.glass"
+      backdropFilter="blur(24px)"
+      borderRight="1px solid"
+      borderColor="border.subtle"
+      transition="width 0.2s cubic-bezier(0.4,0,0.2,1)"
+      display={{ base: 'none', md: 'flex' }}
+      zIndex="99"
+      py="3"
+      overflow="hidden"
+    >
+      <Flex direction="column" gap="1" px="3" flex="1">
+        {navItems.map((item) => {
+          const isActive = pathname.startsWith(item.href)
+          const Icon = item.icon
+
+          return (
+            <Flex
+              key={item.href}
+              asChild
+              alignItems="center"
+              gap="3"
+              px="3"
+              py="2.5"
+              borderRadius="lg"
+              textDecoration="none"
+              fontFamily="mono"
+              fontSize="xs"
+              letterSpacing="0.04em"
+              fontWeight={isActive ? 'medium' : 'normal'}
+              bg={isActive ? 'bg.card' : 'transparent'}
+              color={isActive ? 'action.primary' : 'text.muted'}
+              boxShadow={isActive ? 'sm' : 'none'}
+              _hover={{
+                bg: isActive ? 'bg.card' : 'bg.overlay',
+                color: isActive ? 'action.primary' : 'text.secondary',
+              }}
+              transition="all 0.15s ease"
+            >
+              <Link href={item.href}>
+                <Box flexShrink={0}>
+                  <Icon />
+                </Box>
+                {!collapsed && (
+                  <Box as="span" whiteSpace="nowrap">
+                    {item.label}
+                  </Box>
+                )}
+              </Link>
+            </Flex>
+          )
+        })}
+      </Flex>
+
+      <Flex px="3" pb="2">
+        <IconButton
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          onClick={onToggle}
+          variant="ghost"
+          borderRadius="full"
+          size="sm"
+          color="text.muted"
+          _hover={{ bg: 'bg.overlay', color: 'text.secondary' }}
+          transform={collapsed ? 'rotate(180deg)' : undefined}
+          transition="transform 0.2s ease"
+        >
+          <ChevronLeftIcon />
+        </IconButton>
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/components/portal/top-bar.test.tsx
+++ b/src/components/portal/top-bar.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@/test/render'
+import { TopBar } from './top-bar'
+
+vi.mock('next-themes', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+  useTheme: () => ({
+    resolvedTheme: 'light',
+    setTheme: vi.fn(),
+  }),
+}))
+
+describe('TopBar', () => {
+  it('renders the Aarogya logo text', () => {
+    render(<TopBar onMenuToggle={vi.fn()} />)
+    expect(screen.getByText('Aarogya')).toBeInTheDocument()
+  })
+
+  it('renders the notifications bell button', () => {
+    render(<TopBar onMenuToggle={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument()
+  })
+
+  it('renders the color mode toggle', () => {
+    render(<TopBar onMenuToggle={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /switch to dark mode/i })).toBeInTheDocument()
+  })
+
+  it('renders the mobile menu toggle button', () => {
+    render(<TopBar onMenuToggle={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /toggle menu/i })).toBeInTheDocument()
+  })
+
+  it('calls onMenuToggle when hamburger is clicked', async () => {
+    const onMenuToggle = vi.fn()
+    const { userEvent } = await import('@/test/render')
+    const user = userEvent.setup()
+    render(<TopBar onMenuToggle={onMenuToggle} />)
+
+    await user.click(screen.getByRole('button', { name: /toggle menu/i }))
+    expect(onMenuToggle).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/portal/top-bar.tsx
+++ b/src/components/portal/top-bar.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { Box, Flex, IconButton } from '@chakra-ui/react'
+import { ColorModeToggle } from '@/components/ui/color-mode-toggle'
+import { BellIcon, MenuIcon, UserIcon } from './nav-items'
+
+interface TopBarProps {
+  onMenuToggle: () => void
+}
+
+function ShieldTreeLogo() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 100 100" fill="none"
+      xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M50 5 L85 20 C85 55 72 80 50 95 C28 80 15 55 15 20 Z"
+        fill="currentColor" opacity="0.1" stroke="currentColor"
+        strokeWidth="2" />
+      <line x1="50" y1="45" x2="50" y2="75" stroke="currentColor" strokeWidth="3" />
+      <path d="M50 45 C50 35 35 25 30 30 C35 28 45 35 50 45" fill="currentColor" opacity="0.6" />
+      <path d="M50 45 C50 35 65 25 70 30 C65 28 55 35 50 45" fill="currentColor" opacity="0.6" />
+      <circle cx="50" cy="30" r="14" fill="currentColor" opacity="0.15" />
+      <circle cx="50" cy="28" r="9" fill="currentColor" opacity="0.2" />
+      <path d="M50 75 C45 78 42 80 40 82" stroke="currentColor" strokeWidth="1.5" opacity="0.4" />
+      <path d="M50 75 C55 78 58 80 60 82" stroke="currentColor" strokeWidth="1.5" opacity="0.4" />
+    </svg>
+  )
+}
+
+export function TopBar({ onMenuToggle }: TopBarProps) {
+  return (
+    <Flex
+      as="header"
+      position="sticky"
+      top="0"
+      zIndex="100"
+      height="56px"
+      alignItems="center"
+      px={{ base: 3, md: 5 }}
+      bg="bg.glass"
+      backdropFilter="blur(24px)"
+      borderBottom="1px solid"
+      borderColor="border.subtle"
+    >
+      <IconButton
+        aria-label="Toggle menu"
+        onClick={onMenuToggle}
+        variant="ghost"
+        borderRadius="full"
+        size="sm"
+        color="text.secondary"
+        _hover={{ bg: 'bg.overlay' }}
+        display={{ base: 'flex', md: 'none' }}
+      >
+        <MenuIcon />
+      </IconButton>
+
+      <Flex alignItems="center" gap="2" ml={{ base: 2, md: 0 }}>
+        <Box color="action.primary">
+          <ShieldTreeLogo />
+        </Box>
+        <Box
+          as="span"
+          fontFamily="heading"
+          fontSize="1.2rem"
+          color="text.primary"
+          fontWeight="bold"
+        >
+          Aarogya
+        </Box>
+      </Flex>
+
+      <Flex ml="auto" alignItems="center" gap="1">
+        <IconButton
+          aria-label="Notifications"
+          variant="ghost"
+          borderRadius="full"
+          size="sm"
+          color="text.secondary"
+          _hover={{ bg: 'bg.overlay' }}
+        >
+          <BellIcon />
+        </IconButton>
+
+        <Box
+          borderRadius="full"
+          width="32px"
+          height="32px"
+          bg="bg.overlay"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          color="text.muted"
+        >
+          <UserIcon />
+        </Box>
+
+        <ColorModeToggle />
+      </Flex>
+    </Flex>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds the navigation shell wrapping all protected `(portal)` routes with three components: sticky glassmorphic **TopBar** (logo, notifications bell, user avatar, color mode toggle), collapsible **Sidebar** (desktop, 240px→72px), and floating **BottomNav** pill (mobile)
- Shared `nav-items.tsx` defines routes (Reports, Access, Emergency, Settings) with inline SVG icons
- Active route highlighting via `usePathname()`, all styled with Serene Bloom semantic tokens
- Updates E2E smoke tests to scope page content assertions to `main` role (avoids ambiguity from nav labels)

Closes #7

## Test plan
- [x] `npm run lint` — no errors
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run test:coverage` — 94 tests pass, 100% coverage on all files
- [x] `npm run build` — successful production build
- [x] `npx playwright test --project=chromium` — 9 E2E tests pass (including new sidebar navigation test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)