### PR TITLE
Add Shield Tree loading animation component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.14.0",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-query-devtools": "^5.91.3",
+        "framer-motion": "^12.34.3",
         "next": "^16.1.6",
         "next-themes": "^0.4.4",
         "react": "^19.2.0",
@@ -6300,6 +6301,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.3.tgz",
+      "integrity": "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.34.3",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7616,6 +7644,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
+      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@emotion/react": "^11.14.0",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
+    "framer-motion": "^12.34.3",
     "next": "^16.1.6",
     "next-themes": "^0.4.4",
     "react": "^19.2.0",

--- a/src/components/ui/shield-tree-loader.test.tsx
+++ b/src/components/ui/shield-tree-loader.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@/test/render'
+import { ShieldTreeLoader } from './shield-tree-loader'
+
+let mockResolvedTheme = 'light'
+
+vi.mock('next-themes', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+  useTheme: () => ({
+    resolvedTheme: mockResolvedTheme,
+    setTheme: vi.fn(),
+  }),
+}))
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, prop: string) => {
+        return ({
+          children,
+          ...rest
+        }: React.PropsWithChildren<Record<string, unknown>>) => {
+          const filteredProps: Record<string, unknown> = {}
+          for (const [key, value] of Object.entries(rest)) {
+            if (
+              typeof value !== 'object' &&
+              typeof value !== 'function' &&
+              !['initial', 'animate', 'transition', 'whileHover', 'whileInView'].includes(key)
+            ) {
+              filteredProps[key] = value
+            }
+          }
+          if (prop === 'div') {
+            const { style, ...divProps } = filteredProps as Record<string, unknown> & { style?: React.CSSProperties }
+            return <div style={style as React.CSSProperties} {...divProps}>{children}</div>
+          }
+          // SVG elements — use createElement to avoid JSX namespace issues
+          const element = document.createElementNS('http://www.w3.org/2000/svg', prop)
+          for (const [key, value] of Object.entries(filteredProps)) {
+            if (key === 'data-testid') {
+              element.setAttribute('data-testid', String(value))
+            } else if (typeof value === 'string' || typeof value === 'number') {
+              element.setAttribute(key, String(value))
+            }
+          }
+          return <>{children}</>
+        }
+      },
+    },
+  ),
+}))
+
+describe('ShieldTreeLoader', () => {
+  beforeEach(() => {
+    mockResolvedTheme = 'light'
+  })
+
+  it('renders with status role and aria-label', () => {
+    render(<ShieldTreeLoader />)
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Loading')
+  })
+
+  it('renders SVG with expected viewBox', () => {
+    const { container } = render(<ShieldTreeLoader />)
+    const svg = container.querySelector('svg[viewBox="0 0 80 80"]')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('renders sm size container', () => {
+    const { container } = render(<ShieldTreeLoader size="sm" />)
+    const sizeContainer = container.querySelector('[role="status"] > div')
+    expect(sizeContainer).toHaveStyle({ width: '80px', height: '80px' })
+  })
+
+  it('renders md size container (default)', () => {
+    const { container } = render(<ShieldTreeLoader />)
+    const sizeContainer = container.querySelector('[role="status"] > div')
+    expect(sizeContainer).toHaveStyle({ width: '160px', height: '160px' })
+  })
+
+  it('renders lg size container', () => {
+    const { container } = render(<ShieldTreeLoader size="lg" />)
+    const sizeContainer = container.querySelector('[role="status"] > div')
+    expect(sizeContainer).toHaveStyle({ width: '240px', height: '240px' })
+  })
+
+  it('renders full-page overlay with fixed positioning', () => {
+    const { container } = render(<ShieldTreeLoader variant="fullPage" />)
+    const overlay = container.firstElementChild as HTMLElement
+    expect(overlay).toHaveStyle({ position: 'fixed' })
+  })
+
+  it('does not render full-page overlay for inline variant', () => {
+    const { container } = render(<ShieldTreeLoader variant="inline" />)
+    const statusEl = container.querySelector('[role="status"]')
+    expect(statusEl).toBe(container.firstElementChild)
+  })
+
+  it('shows brand text for fullPage variant by default', () => {
+    render(<ShieldTreeLoader variant="fullPage" />)
+    expect(screen.getByText('Aarogya')).toBeInTheDocument()
+    expect(screen.getByText('Your Health, Our Priority')).toBeInTheDocument()
+  })
+
+  it('hides brand text for inline variant by default', () => {
+    render(<ShieldTreeLoader variant="inline" />)
+    expect(screen.queryByText('Aarogya')).not.toBeInTheDocument()
+  })
+
+  it('shows brand text when showBrandText is true', () => {
+    render(<ShieldTreeLoader showBrandText />)
+    expect(screen.getByText('Aarogya')).toBeInTheDocument()
+  })
+
+  it('hides brand text when showBrandText is false on fullPage', () => {
+    render(<ShieldTreeLoader variant="fullPage" showBrandText={false} />)
+    expect(screen.queryByText('Aarogya')).not.toBeInTheDocument()
+  })
+
+  it('shows progress bar for fullPage variant by default', () => {
+    render(<ShieldTreeLoader variant="fullPage" />)
+    expect(screen.getByText('Growing your wellness journey...')).toBeInTheDocument()
+  })
+
+  it('hides progress bar for inline variant by default', () => {
+    render(<ShieldTreeLoader variant="inline" />)
+    expect(screen.queryByText('Growing your wellness journey...')).not.toBeInTheDocument()
+  })
+
+  it('shows progress bar when showProgress is true', () => {
+    render(<ShieldTreeLoader showProgress />)
+    expect(screen.getByText('Growing your wellness journey...')).toBeInTheDocument()
+  })
+
+  it('hides progress bar when showProgress is false on fullPage', () => {
+    render(<ShieldTreeLoader variant="fullPage" showProgress={false} />)
+    expect(screen.queryByText('Growing your wellness journey...')).not.toBeInTheDocument()
+  })
+
+  it('renders three ripple elements', () => {
+    render(<ShieldTreeLoader />)
+    const ripples = screen.getAllByTestId('ripple')
+    expect(ripples).toHaveLength(3)
+  })
+
+  it('renders in dark mode without errors', () => {
+    mockResolvedTheme = 'dark'
+    render(<ShieldTreeLoader variant="fullPage" />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByText('Aarogya')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/shield-tree-loader.tsx
+++ b/src/components/ui/shield-tree-loader.tsx
@@ -1,0 +1,354 @@
+'use client'
+
+import { Box, Text } from '@chakra-ui/react'
+import { motion } from 'framer-motion'
+import { useTheme } from 'next-themes'
+
+export interface ShieldTreeLoaderProps {
+  size?: 'sm' | 'md' | 'lg'
+  variant?: 'inline' | 'fullPage'
+  showProgress?: boolean
+  showBrandText?: boolean
+}
+
+const SIZE_MAP = { sm: 80, md: 160, lg: 240 } as const
+
+/** Unique IDs per instance to avoid SVG gradient conflicts when multiple loaders render */
+let instanceCounter = 0
+
+export function ShieldTreeLoader({
+  size = 'md',
+  variant = 'inline',
+  showProgress,
+  showBrandText,
+}: ShieldTreeLoaderProps) {
+  const { resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark'
+  const px = SIZE_MAP[size]
+
+  const shouldShowProgress = showProgress ?? variant === 'fullPage'
+  const shouldShowBrandText = showBrandText ?? variant === 'fullPage'
+
+  const id = `stl-${++instanceCounter}`
+
+  const shieldGradient = isDark
+    ? { start: '#1A9E97', end: '#0E6B66' }
+    : { start: '#0E6B66', end: '#0A4D4A' }
+
+  const canopyGradient = isDark
+    ? { start: 'rgba(168,213,174,0.5)', end: 'rgba(26,158,151,0.3)' }
+    : { start: '#A8D5AE', mid: '#7FB285', end: '#0E6B66' }
+
+  const strokeColor = isDark ? 'rgba(255,255,255,0.4)' : '#FFF8F0'
+  const rootOpacity = isDark ? 0.15 : 0.3
+  const branchOpacity = isDark ? 0.2 : 0.35
+  const shieldStroke = isDark ? '#1A9E97' : '#0E6B66'
+
+  const content = (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      role="status"
+      aria-label="Loading"
+    >
+      {/* Tree animation container */}
+      <Box position="relative" width={`${px}px`} height={`${px}px`}>
+        {/* Ripples */}
+        {[1, 2, 3].map((i) => (
+          <Box
+            key={i}
+            data-testid="ripple"
+            position="absolute"
+            top="62%"
+            left="50%"
+            transform="translate(-50%, -50%)"
+            borderRadius="full"
+            borderStyle="solid"
+            borderWidth="1.5px"
+            borderColor={
+              isDark
+                ? ['', '#1A9E97', '#A8D5AE', '#FFD693'][i]
+                : ['', '#0E6B66', '#7FB285', '#FFB347'][i]
+            }
+            opacity={0}
+            pointerEvents="none"
+            css={{
+              animation: `shieldTreeRipple 3.5s ease-out ${1.6 + i * 0.6}s infinite`,
+            }}
+          />
+        ))}
+
+        {/* Tree SVG */}
+        <svg
+          style={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: '80%',
+            height: '80%',
+          }}
+          viewBox="0 0 80 80"
+          fill="none"
+          aria-hidden="true"
+        >
+          <defs>
+            <linearGradient
+              id={`${id}-shield`}
+              x1="20"
+              y1="4"
+              x2="60"
+              y2="76"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0%" stopColor={shieldGradient.start} />
+              <stop offset="100%" stopColor={shieldGradient.end} />
+            </linearGradient>
+            <linearGradient
+              id={`${id}-canopy`}
+              x1="24"
+              y1="14"
+              x2="56"
+              y2="48"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0%" stopColor={canopyGradient.start} />
+              {'mid' in canopyGradient && (
+                <stop offset="50%" stopColor={canopyGradient.mid} />
+              )}
+              <stop offset="100%" stopColor={canopyGradient.end} />
+            </linearGradient>
+          </defs>
+
+          {/* Shield */}
+          <motion.path
+            d="M40 4 C22 4 10 10 10 10 L10 36 C10 56 24 70 40 76 C56 70 70 56 70 36 L70 10 C70 10 58 4 40 4Z"
+            fill={`url(#${id}-shield)`}
+            stroke={shieldStroke}
+            strokeWidth={1}
+            initial={{ strokeDasharray: 300, strokeDashoffset: 300, fillOpacity: 0 }}
+            animate={{ strokeDashoffset: 0, fillOpacity: 0.9 }}
+            transition={{ delay: 0.3, duration: 1.5, ease: 'easeOut' }}
+          />
+
+          {/* Seed */}
+          <motion.circle
+            cx={40}
+            cy={66}
+            r={3}
+            fill="#FFB347"
+            initial={{ opacity: 0, scale: 0 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{
+              delay: 1.2,
+              duration: 0.8,
+              ease: 'easeOut',
+              scale: {
+                delay: 1.2,
+                duration: 0.8,
+                type: 'spring',
+                stiffness: 300,
+                damping: 15,
+              },
+            }}
+          />
+
+          {/* Trunk */}
+          <motion.path
+            d="M40 66 L40 44"
+            stroke={strokeColor}
+            strokeWidth={3}
+            strokeLinecap="round"
+            initial={{ strokeDasharray: 40, strokeDashoffset: 40, opacity: 0 }}
+            animate={{ strokeDashoffset: 0, opacity: 0.5 }}
+            transition={{ delay: 1.8, duration: 1.0, ease: 'easeOut' }}
+          />
+
+          {/* Roots */}
+          <g data-testid="roots">
+            {[
+              'M40 66 C36 68 30 69 28 68',
+              'M40 66 C44 68 50 69 52 68',
+              'M40 66 C38 69 36 71 34 71',
+              'M40 66 C42 69 44 71 46 71',
+            ].map((d, i) => (
+              <motion.path
+                key={d}
+                d={d}
+                stroke={strokeColor}
+                strokeWidth={i < 2 ? 1.2 : 1}
+                strokeLinecap="round"
+                initial={{ strokeDasharray: 30, strokeDashoffset: 30, opacity: 0 }}
+                animate={{ strokeDashoffset: 0, opacity: rootOpacity }}
+                transition={{ delay: 2.0 + i * 0.1, duration: 0.8, ease: 'easeOut' }}
+              />
+            ))}
+          </g>
+
+          {/* Branches */}
+          <g data-testid="branches">
+            {[
+              'M40 48 C34 44 28 42 24 42',
+              'M40 48 C46 44 52 42 56 42',
+              'M40 44 C36 40 32 36 30 34',
+              'M40 44 C44 40 48 36 50 34',
+            ].map((d, i) => (
+              <motion.path
+                key={d}
+                d={d}
+                stroke={strokeColor}
+                strokeWidth={i < 2 ? 1.5 : 1.2}
+                strokeLinecap="round"
+                initial={{ strokeDasharray: 30, strokeDashoffset: 30, opacity: 0 }}
+                animate={{ strokeDashoffset: 0, opacity: branchOpacity }}
+                transition={{ delay: 2.4 + i * 0.1, duration: 0.7, ease: 'easeOut' }}
+              />
+            ))}
+          </g>
+
+          {/* Canopy */}
+          <g data-testid="canopy">
+            {[
+              { cx: 40, cy: 36, rx: 22, ry: 16, fill: `url(#${id}-canopy)`, opacity: isDark ? 0.5 : 0.45 },
+              { cx: 40, cy: 32, rx: 17, ry: 13, fill: isDark ? 'rgba(168,213,174,0.2)' : '#7FB285', opacity: isDark ? 1 : 0.4 },
+              { cx: 40, cy: 27, rx: 12, ry: 10, fill: isDark ? 'rgba(168,213,174,0.15)' : '#A8D5AE', opacity: isDark ? 1 : 0.35 },
+              { cx: 40, cy: 22, rx: 7, ry: 6, fill: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(255,255,255,0.3)', opacity: 1 },
+            ].map((e, i) => (
+              <motion.ellipse
+                key={i}
+                cx={e.cx}
+                cy={e.cy}
+                rx={e.rx}
+                ry={e.ry}
+                fill={e.fill}
+                initial={{ opacity: 0, scale: 0.2 }}
+                animate={{ opacity: e.opacity, scale: 1 }}
+                transition={{
+                  delay: 2.8 + i * 0.2,
+                  duration: 0.8,
+                  type: 'spring',
+                  stiffness: 200,
+                  damping: 12,
+                }}
+              />
+            ))}
+          </g>
+
+          {/* Ground glow */}
+          <motion.ellipse
+            cx={40}
+            cy={68}
+            rx={12}
+            ry={2.5}
+            fill="#FFB347"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 0.3 }}
+            transition={{ delay: 3.2, duration: 1.0, ease: 'easeOut' }}
+          />
+        </svg>
+      </Box>
+
+      {/* Brand text */}
+      {shouldShowBrandText && (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 3.5, duration: 1.2, ease: 'easeOut' }}
+        >
+          <Text
+            fontFamily="heading"
+            fontSize="5xl"
+            lineHeight={1}
+            color="text.primary"
+          >
+            Aarogya
+          </Text>
+          <Text
+            fontWeight="light"
+            fontSize="sm"
+            letterSpacing="0.15em"
+            textTransform="uppercase"
+            color="text.secondary"
+            mt={2}
+            textAlign="center"
+          >
+            Your Health, Our Priority
+          </Text>
+        </motion.div>
+      )}
+
+      {/* Progress bar */}
+      {shouldShowProgress && (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 4.0, duration: 1.0, ease: 'easeOut' }}
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '14px', marginTop: '40px' }}
+        >
+          <Box
+            width="200px"
+            height="3px"
+            borderRadius="full"
+            overflow="hidden"
+            bg={isDark ? 'rgba(255,255,255,0.08)' : 'rgba(10,77,74,0.1)'}
+          >
+            <Box
+              height="100%"
+              borderRadius="full"
+              bg="linear-gradient(90deg, #0E6B66, #7FB285, #FFB347)"
+              css={{
+                animation: 'shieldTreeProgress 4s ease-in-out 4.3s infinite',
+                width: '0%',
+              }}
+            />
+          </Box>
+          <Text
+            fontWeight="light"
+            fontSize="xs"
+            letterSpacing="0.1em"
+            color="text.muted"
+          >
+            Growing your wellness journey...
+          </Text>
+        </motion.div>
+      )}
+
+      {/* Global keyframes injected via style tag */}
+      <style>{`
+        @keyframes shieldTreeRipple {
+          0% { width: 40px; height: 40px; opacity: 0.7; border-width: 2px; }
+          100% { width: 280px; height: 280px; opacity: 0; border-width: 0.5px; }
+        }
+        @keyframes shieldTreeProgress {
+          0% { width: 0%; }
+          20% { width: 25%; }
+          50% { width: 55%; }
+          70% { width: 72%; }
+          90% { width: 90%; }
+          100% { width: 100%; }
+        }
+      `}</style>
+    </Box>
+  )
+
+  if (variant === 'fullPage') {
+    return (
+      <Box
+        position="fixed"
+        inset={0}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        bg="bg.overlay"
+        zIndex={9999}
+        backdropFilter="blur(4px)"
+      >
+        {content}
+      </Box>
+    )
+  }
+
+  return content
+}


### PR DESCRIPTION
## Summary
- Adds reusable `ShieldTreeLoader` component with Framer Motion orchestrated seed-to-tree growth animation matching the design reference (`docs/design-assets/loading-shield-tree.html`)
- Supports `sm` (80px), `md` (160px), `lg` (240px) size variants and `inline`/`fullPage` overlay variants
- Automatic light/dark color mode switching via `useTheme()` from next-themes
- Optional brand text ("Aarogya") and progress bar with gradient fill, defaulting to visible for `fullPage` variant
- CSS `@keyframes` for infinite ripples, Framer Motion for sequenced tree growth (shield draw → seed pop → trunk → roots → branches → canopy bloom → ground glow)

Closes #8

## Test plan
- [x] 17 unit tests covering all props, sizes, variants, and dark mode — all passing
- [x] 100% line/branch/function coverage maintained
- [x] `npm run build` succeeds with no type errors
- [x] `npm run lint` passes clean
- [ ] Visual verification: render component at each size in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)