### PR TITLE
Add access grant API hooks with TanStack Query (#20)

### DIFF
--- a/src/hooks/access/index.ts
+++ b/src/hooks/access/index.ts
@@ -1,0 +1,4 @@
+export { useAccessGrants } from './use-access-grants'
+export { useSearchDoctors } from './use-search-doctors'
+export { useCreateGrant } from './use-create-grant'
+export { useRevokeGrant } from './use-revoke-grant'

--- a/src/hooks/access/use-access-grants.test.tsx
+++ b/src/hooks/access/use-access-grants.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { clearEtagCache } from '@/lib/api/client'
+import { useAccessGrants } from './use-access-grants'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  clearEtagCache()
+})
+
+describe('useAccessGrants', () => {
+  it('fetches access grants successfully', async () => {
+    const data = {
+      items: [
+        {
+          id: 'ag1',
+          doctorId: 'd1',
+          doctorName: 'Dr. Smith',
+          reportIds: ['r1'],
+          expiresAt: '2025-06-01T00:00:00Z',
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalCount: 1,
+      totalPages: 1,
+    }
+    mockFetch.mockResolvedValue(jsonResponse(data))
+
+    const { result } = renderHook(() => useAccessGrants(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(data)
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/v1/access-grants')
+  })
+
+  it('returns error state on failure', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: 'Internal server error' }, 500),
+    )
+
+    const { result } = renderHook(() => useAccessGrants(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toMatchObject({ status: 500 })
+  })
+})

--- a/src/hooks/access/use-access-grants.ts
+++ b/src/hooks/access/use-access-grants.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import { staleTimes } from '@/lib/api/stale-times'
+import type { AccessGrantListResponse } from '@/types/access'
+
+export function useAccessGrants() {
+  return useQuery({
+    queryKey: queryKeys.accessGrants.list(),
+    queryFn: () => apiFetch<AccessGrantListResponse>('/v1/access-grants'),
+    staleTime: staleTimes.accessGrants,
+  })
+}

--- a/src/hooks/access/use-create-grant.test.tsx
+++ b/src/hooks/access/use-create-grant.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { clearEtagCache } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import { useCreateGrant } from './use-create-grant'
+import type { AccessGrantListResponse } from '@/types/access'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+let queryClient: QueryClient
+
+function createWrapper(gcTime = 0) {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+const grantRequest = {
+  doctorId: 'd1',
+  doctorName: 'Dr. Smith',
+  reportIds: ['r1', 'r2'],
+  expiresAt: '2025-06-01T00:00:00Z',
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  clearEtagCache()
+})
+
+describe('useCreateGrant', () => {
+  it('sends POST request with grant data', async () => {
+    const created = {
+      id: 'ag1',
+      ...grantRequest,
+      createdAt: '2025-01-15T10:00:00Z',
+    }
+    mockFetch.mockResolvedValue(jsonResponse(created))
+
+    const { result } = renderHook(() => useCreateGrant(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(() => result.current.mutateAsync(grantRequest))
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(created)
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/v1/access-grants')
+
+    const calledInit = mockFetch.mock.calls[0][1] as RequestInit
+    expect(calledInit.method).toBe('POST')
+    expect(JSON.parse(calledInit.body as string)).toEqual(grantRequest)
+  })
+
+  it('optimistically adds grant to list cache', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: AccessGrantListResponse = {
+      items: [
+        {
+          id: 'ag-existing',
+          doctorId: 'd2',
+          doctorName: 'Dr. Jones',
+          reportIds: ['r3'],
+          expiresAt: '2025-07-01T00:00:00Z',
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalCount: 1,
+      totalPages: 1,
+    }
+
+    queryClient.setQueryData(queryKeys.accessGrants.list(), initialData)
+
+    let resolveCreate!: () => void
+    mockFetch.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveCreate = () =>
+          resolve(
+            jsonResponse({
+              id: 'ag-new',
+              ...grantRequest,
+              createdAt: '2025-01-15T10:00:00Z',
+            }),
+          )
+      }),
+    )
+
+    const { result } = renderHook(() => useCreateGrant(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate(grantRequest)
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<AccessGrantListResponse>(
+        queryKeys.accessGrants.list(),
+      )
+      expect(cached?.items).toHaveLength(2)
+      expect(cached?.items[0].id).toMatch(/^optimistic-/)
+      expect(cached?.items[0].doctorName).toBe('Dr. Smith')
+      expect(cached?.totalCount).toBe(2)
+    })
+
+    await act(async () => {
+      resolveCreate()
+    })
+  })
+
+  it('rolls back cache on error', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: AccessGrantListResponse = {
+      items: [
+        {
+          id: 'ag-existing',
+          doctorId: 'd2',
+          doctorName: 'Dr. Jones',
+          reportIds: ['r3'],
+          expiresAt: '2025-07-01T00:00:00Z',
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalCount: 1,
+      totalPages: 1,
+    }
+
+    queryClient.setQueryData(queryKeys.accessGrants.list(), initialData)
+
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Bad Request' }, 400))
+
+    const { result } = renderHook(() => useCreateGrant(), { wrapper })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(grantRequest)
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<AccessGrantListResponse>(
+        queryKeys.accessGrants.list(),
+      )
+      expect(cached?.items).toHaveLength(1)
+      expect(cached?.items[0].id).toBe('ag-existing')
+      expect(cached?.totalCount).toBe(1)
+    })
+  })
+})

--- a/src/hooks/access/use-create-grant.ts
+++ b/src/hooks/access/use-create-grant.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import type {
+  AccessGrant,
+  AccessGrantListResponse,
+  CreateAccessGrantRequest,
+} from '@/types/access'
+
+export function useCreateGrant() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (request: CreateAccessGrantRequest) =>
+      apiFetch<AccessGrant>('/v1/access-grants', {
+        method: 'POST',
+        body: request,
+      }),
+    onMutate: async (request) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.accessGrants.all })
+
+      const previousLists = queryClient.getQueriesData<AccessGrantListResponse>(
+        { queryKey: queryKeys.accessGrants.all },
+      )
+
+      queryClient.setQueriesData<AccessGrantListResponse>(
+        { queryKey: queryKeys.accessGrants.all },
+        (old) => {
+          if (!old?.items) return old
+          const optimisticGrant: AccessGrant = {
+            id: `optimistic-${Date.now()}`,
+            doctorId: request.doctorId,
+            doctorName: request.doctorName,
+            reportIds: request.reportIds,
+            expiresAt: request.expiresAt,
+            createdAt: new Date().toISOString(),
+          }
+          return {
+            ...old,
+            items: [optimisticGrant, ...old.items],
+            totalCount: old.totalCount + 1,
+          }
+        },
+      )
+
+      return { previousLists }
+    },
+    onError: (_err, _request, context) => {
+      if (context?.previousLists) {
+        for (const [key, data] of context.previousLists) {
+          queryClient.setQueryData(key, data)
+        }
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.accessGrants.all })
+    },
+  })
+}

--- a/src/hooks/access/use-revoke-grant.test.tsx
+++ b/src/hooks/access/use-revoke-grant.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { clearEtagCache } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import { useRevokeGrant } from './use-revoke-grant'
+import type { AccessGrantListResponse } from '@/types/access'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+let queryClient: QueryClient
+
+function createWrapper(gcTime = 0) {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+const grantOne = {
+  id: 'ag1',
+  doctorId: 'd1',
+  doctorName: 'Dr. Smith',
+  reportIds: ['r1'],
+  expiresAt: '2025-06-01T00:00:00Z',
+  createdAt: '2025-01-01T00:00:00Z',
+}
+
+const grantTwo = {
+  id: 'ag2',
+  doctorId: 'd2',
+  doctorName: 'Dr. Jones',
+  reportIds: ['r2'],
+  expiresAt: '2025-07-01T00:00:00Z',
+  createdAt: '2025-01-02T00:00:00Z',
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  clearEtagCache()
+})
+
+describe('useRevokeGrant', () => {
+  it('sends DELETE request', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(null, { status: 204, statusText: 'No Content' }),
+    )
+
+    const { result } = renderHook(() => useRevokeGrant(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(() => result.current.mutateAsync('ag1'))
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/access-grants/ag1'),
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+  })
+
+  it('optimistically removes grant from list cache', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: AccessGrantListResponse = {
+      items: [grantOne, grantTwo],
+      page: 1,
+      pageSize: 10,
+      totalCount: 2,
+      totalPages: 1,
+    }
+
+    queryClient.setQueryData(queryKeys.accessGrants.list(), initialData)
+
+    let resolveDelete!: () => void
+    mockFetch.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveDelete = () =>
+          resolve(new Response(null, { status: 204 }))
+      }),
+    )
+
+    const { result } = renderHook(() => useRevokeGrant(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate('ag1')
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<AccessGrantListResponse>(
+        queryKeys.accessGrants.list(),
+      )
+      expect(cached?.items).toHaveLength(1)
+      expect(cached?.items[0].id).toBe('ag2')
+      expect(cached?.totalCount).toBe(1)
+    })
+
+    await act(async () => {
+      resolveDelete()
+    })
+  })
+
+  it('rolls back cache on error', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: AccessGrantListResponse = {
+      items: [grantOne],
+      page: 1,
+      pageSize: 10,
+      totalCount: 1,
+      totalPages: 1,
+    }
+
+    queryClient.setQueryData(queryKeys.accessGrants.list(), initialData)
+
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Forbidden' }, 403))
+
+    const { result } = renderHook(() => useRevokeGrant(), { wrapper })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync('ag1')
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<AccessGrantListResponse>(
+        queryKeys.accessGrants.list(),
+      )
+      expect(cached?.items).toHaveLength(1)
+      expect(cached?.items[0].id).toBe('ag1')
+    })
+  })
+})

--- a/src/hooks/access/use-revoke-grant.ts
+++ b/src/hooks/access/use-revoke-grant.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import type { AccessGrantListResponse } from '@/types/access'
+
+export function useRevokeGrant() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiFetch<void>(`/v1/access-grants/${id}`, { method: 'DELETE' }),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.accessGrants.all })
+
+      const previousLists = queryClient.getQueriesData<AccessGrantListResponse>(
+        { queryKey: queryKeys.accessGrants.all },
+      )
+
+      queryClient.setQueriesData<AccessGrantListResponse>(
+        { queryKey: queryKeys.accessGrants.all },
+        (old) => {
+          if (!old?.items) return old
+          return {
+            ...old,
+            items: old.items.filter((g) => g.id !== id),
+            totalCount: old.totalCount - 1,
+          }
+        },
+      )
+
+      return { previousLists }
+    },
+    onError: (_err, _id, context) => {
+      if (context?.previousLists) {
+        for (const [key, data] of context.previousLists) {
+          queryClient.setQueryData(key, data)
+        }
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.accessGrants.all })
+    },
+  })
+}

--- a/src/hooks/access/use-search-doctors.test.tsx
+++ b/src/hooks/access/use-search-doctors.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { clearEtagCache } from '@/lib/api/client'
+import { useSearchDoctors } from './use-search-doctors'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  clearEtagCache()
+})
+
+describe('useSearchDoctors', () => {
+  it('fetches doctor search results', async () => {
+    const data = {
+      items: [
+        {
+          id: 'd1',
+          name: 'Dr. Smith',
+          specialisation: 'Cardiology',
+          registrationNumber: 'MCI-12345',
+        },
+      ],
+    }
+    mockFetch.mockResolvedValue(jsonResponse(data))
+
+    const { result } = renderHook(() => useSearchDoctors('Smith'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(data)
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/v1/doctors/search?q=Smith')
+  })
+
+  it('returns error state on failure', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: 'Service unavailable' }, 503),
+    )
+
+    const { result } = renderHook(() => useSearchDoctors('Smith'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toMatchObject({ status: 503 })
+  })
+
+  it('does not fetch when query is shorter than 2 characters', async () => {
+    const { result } = renderHook(() => useSearchDoctors('S'), {
+      wrapper: createWrapper(),
+    })
+
+    // Wait a tick for the initial render to settle
+    await waitFor(() => expect(result.current.fetchStatus).toBe('idle'))
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('debounces the search query', async () => {
+    vi.useFakeTimers()
+
+    mockFetch.mockResolvedValue(jsonResponse({ items: [] }))
+
+    // Start with a short query that won't trigger a fetch
+    const { rerender } = renderHook(
+      ({ query }: { query: string }) => useSearchDoctors(query),
+      {
+        wrapper: createWrapper(),
+        initialProps: { query: '' },
+      },
+    )
+
+    // Rapid re-renders with different queries
+    rerender({ query: 'Sm' })
+    rerender({ query: 'Smi' })
+    rerender({ query: 'Smit' })
+
+    // No fetch should have happened yet — debounce hasn't fired
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    // Advance past debounce
+    await act(async () => {
+      vi.advanceTimersByTime(300)
+    })
+
+    // Now the debounced value should trigger a single fetch
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('q=Smit')
+
+    vi.useRealTimers()
+  })
+})

--- a/src/hooks/access/use-search-doctors.ts
+++ b/src/hooks/access/use-search-doctors.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api/client'
+import { useDebouncedValue } from '@/hooks/use-debounced-value'
+import type { DoctorSearchResult } from '@/types/access'
+
+export function useSearchDoctors(query: string) {
+  const debouncedQuery = useDebouncedValue(query, 300)
+
+  return useQuery({
+    queryKey: ['doctors', 'search', debouncedQuery],
+    queryFn: () =>
+      apiFetch<DoctorSearchResult>(
+        `/v1/doctors/search?q=${encodeURIComponent(debouncedQuery)}`,
+      ),
+    enabled: debouncedQuery.trim().length >= 2,
+  })
+}

--- a/src/types/access.ts
+++ b/src/types/access.ts
@@ -1,0 +1,34 @@
+export interface Doctor {
+  id: string
+  name: string
+  specialisation: string
+  registrationNumber: string
+}
+
+export interface DoctorSearchResult {
+  items: Doctor[]
+}
+
+export interface AccessGrant {
+  id: string
+  doctorId: string
+  doctorName: string
+  reportIds: string[]
+  expiresAt: string
+  createdAt: string
+}
+
+export interface AccessGrantListResponse {
+  items: AccessGrant[]
+  page: number
+  pageSize: number
+  totalCount: number
+  totalPages: number
+}
+
+export interface CreateAccessGrantRequest {
+  doctorId: string
+  doctorName: string
+  reportIds: string[]
+  expiresAt: string
+}


### PR DESCRIPTION
## Summary
- Add `AccessGrant`, `Doctor`, and related TypeScript types in `src/types/access.ts`
- Add `useAccessGrants` hook for listing active grants (1 min stale time)
- Add `useSearchDoctors` hook with 300ms debounce and min 2-char query gate
- Add `useCreateGrant` hook with optimistic list prepend and rollback on error
- Add `useRevokeGrant` hook with optimistic list removal and rollback on error
- Add barrel exports in `src/hooks/access/index.ts`

## Test plan
- [x] `useAccessGrants` — success fetch, error state
- [x] `useSearchDoctors` — success fetch, error state, disabled for short query, debounce behavior
- [x] `useCreateGrant` — POST request, optimistic add to cache, rollback on error
- [x] `useRevokeGrant` — DELETE request, optimistic remove from cache, rollback on error
- [x] All 521 tests pass, lint clean, type-check clean
- [x] 100% line coverage on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)