### PR TITLE
Add doctor access management page (#21)

### DIFF
--- a/src/app/(portal)/access/page.test.tsx
+++ b/src/app/(portal)/access/page.test.tsx
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, userEvent, waitFor } from '@/test/render'
+import AccessPage from './page'
+import type { AccessGrantListResponse } from '@/types/access'
+import type { ReportListResponse } from '@/types/reports'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const activeGrant = {
+  id: 'g1',
+  doctorId: 'd1',
+  doctorName: 'Dr. Priya Sharma',
+  reportIds: ['r1', 'r2', 'r3'],
+  expiresAt: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+  createdAt: '2025-01-01T00:00:00Z',
+}
+
+const expiringGrant = {
+  id: 'g2',
+  doctorId: 'd2',
+  doctorName: 'Dr. Rajesh Kumar',
+  reportIds: ['r1'],
+  expiresAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+  createdAt: '2025-01-10T00:00:00Z',
+}
+
+const expiredGrant = {
+  id: 'g3',
+  doctorId: 'd3',
+  doctorName: 'Dr. Anita Desai',
+  reportIds: ['r2'],
+  expiresAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+  createdAt: '2024-12-01T00:00:00Z',
+}
+
+const mockGrantData: AccessGrantListResponse = {
+  items: [activeGrant, expiringGrant, expiredGrant],
+  page: 1,
+  pageSize: 20,
+  totalCount: 3,
+  totalPages: 1,
+}
+
+const emptyGrantData: AccessGrantListResponse = {
+  items: [],
+  page: 1,
+  pageSize: 20,
+  totalCount: 0,
+  totalPages: 0,
+}
+
+const mockReports: ReportListResponse = {
+  items: [
+    {
+      id: 'r1',
+      title: 'Complete Blood Count',
+      reportType: 'lab',
+      status: 'verified',
+      reportDate: '2025-01-15T00:00:00Z',
+      labName: 'Thyrocare',
+      doctorName: null,
+      notes: null,
+      highlightParameter: null,
+      createdAt: '2025-01-15T10:00:00Z',
+      updatedAt: '2025-01-15T10:00:00Z',
+    },
+    {
+      id: 'r2',
+      title: 'Chest X-Ray',
+      reportType: 'imaging',
+      status: 'verified',
+      reportDate: '2025-02-10T00:00:00Z',
+      labName: null,
+      doctorName: null,
+      notes: null,
+      highlightParameter: null,
+      createdAt: '2025-02-10T10:00:00Z',
+      updatedAt: '2025-02-10T10:00:00Z',
+    },
+  ],
+  page: 1,
+  pageSize: 100,
+  totalCount: 2,
+  totalPages: 1,
+}
+
+function mockFetchHandler(url: string) {
+  if (url.includes('/v1/access-grants')) return jsonResponse(mockGrantData)
+  if (url.includes('/v1/reports')) return jsonResponse(mockReports)
+  if (url.includes('/v1/doctors/search')) {
+    return jsonResponse({
+      items: [
+        {
+          id: 'doc1',
+          name: 'Dr. Arun Mehta',
+          specialisation: 'Orthopedic',
+          registrationNumber: 'MH12345',
+        },
+      ],
+    })
+  }
+  return jsonResponse({})
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('AccessPage', () => {
+  it('shows loading skeleton on initial render', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}))
+    render(<AccessPage />)
+    expect(screen.getByTestId('access-loading')).toBeInTheDocument()
+  })
+
+  it('renders active and expired grant sections', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Priya Sharma')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Active Grants')).toBeInTheDocument()
+    expect(screen.getByText('Expired Grants')).toBeInTheDocument()
+    expect(screen.getByText('Dr. Rajesh Kumar')).toBeInTheDocument()
+    expect(screen.getByText('Dr. Anita Desai')).toBeInTheDocument()
+  })
+
+  it('renders page heading and Grant Access button', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    expect(screen.getByRole('heading', { name: 'Doctor Access' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /grant access/i })).toBeInTheDocument()
+  })
+
+  it('shows empty state when no grants exist', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/v1/access-grants')) return Promise.resolve(jsonResponse(emptyGrantData))
+      return Promise.resolve(jsonResponse({}))
+    })
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No active grants')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Grant a doctor access to your reports')).toBeInTheDocument()
+  })
+
+  it('shows correct grant card count', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('grant-card')).toHaveLength(3)
+    })
+  })
+
+  it('shows active/expiring/expired status badges', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Expiring Soon')).toBeInTheDocument()
+    expect(screen.getByText('Expired')).toBeInTheDocument()
+  })
+
+  it('opens revoke dialog when Revoke is clicked', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Priya Sharma')).toBeInTheDocument()
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /revoke access for dr\. priya sharma/i }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Revoke Access')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText(/will no longer be able to view/),
+    ).toBeInTheDocument()
+  })
+
+  it('confirms revoke and sends DELETE request', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Priya Sharma')).toBeInTheDocument()
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /revoke access for dr\. priya sharma/i }),
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Revoke Access')).toBeInTheDocument()
+    })
+
+    mockFetch.mockResolvedValue(jsonResponse(null, 200))
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+
+    await waitFor(() => {
+      const calls = mockFetch.mock.calls
+      const deleteCall = calls.find((call) => {
+        const url = call[0] as string
+        return url.includes('/v1/access-grants/g1')
+      })
+      expect(deleteCall).toBeTruthy()
+    })
+  })
+
+  it('closes revoke dialog when Cancel is clicked', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Priya Sharma')).toBeInTheDocument()
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /revoke access for dr\. priya sharma/i }),
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Revoke Access')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => {
+      expect(screen.queryByText(/will no longer be able to view/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('opens grant modal when Grant Access button is clicked', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    await userEvent.click(screen.getByRole('button', { name: /grant access/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Grant Doctor Access')).toBeInTheDocument()
+    })
+    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument()
+  })
+
+  it('opens grant modal from empty state CTA', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/v1/access-grants')) return Promise.resolve(jsonResponse(emptyGrantData))
+      return Promise.resolve(jsonResponse(mockReports))
+    })
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No active grants')).toBeInTheDocument()
+    })
+
+    // The empty state also has a "Grant Access" button
+    const buttons = screen.getAllByRole('button', { name: /grant access/i })
+    await userEvent.click(buttons[buttons.length - 1])
+
+    await waitFor(() => {
+      expect(screen.getByText('Grant Doctor Access')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/app/(portal)/access/page.tsx
+++ b/src/app/(portal)/access/page.tsx
@@ -1,3 +1,181 @@
+'use client'
+
+import { useState, useMemo, useCallback } from 'react'
+import { Box, Heading, Skeleton, VStack } from '@chakra-ui/react'
+import { useAccessGrants, useRevokeGrant, useCreateGrant } from '@/hooks/access'
+import { AccessPageHeader, GrantCard, GrantModal } from '@/components/access'
+import { getGrantStatus } from '@/components/access/access-constants'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { EmptyStateView } from '@/components/ui/empty-state'
+import type { AccessGrant } from '@/types/access'
+
 export default function AccessPage() {
-  return <div>Access Grants</div>
+  const { data, isLoading } = useAccessGrants()
+  const revokeGrant = useRevokeGrant()
+  const createGrant = useCreateGrant()
+
+  const [modalOpen, setModalOpen] = useState(false)
+  const [revokeTarget, setRevokeTarget] = useState<AccessGrant | null>(null)
+
+  const grants = useMemo(() => data?.items ?? [], [data])
+
+  const activeGrants = useMemo(
+    () => grants.filter((g) => getGrantStatus(g.expiresAt).status !== 'expired'),
+    [grants],
+  )
+
+  const expiredGrants = useMemo(
+    () => grants.filter((g) => getGrantStatus(g.expiresAt).status === 'expired'),
+    [grants],
+  )
+
+  const handleRevokeClick = useCallback(
+    (id: string) => {
+      const grant = grants.find((g) => g.id === id)
+      if (grant) setRevokeTarget(grant)
+    },
+    [grants],
+  )
+
+  const handleRevokeConfirm = useCallback(() => {
+    if (!revokeTarget) return
+    revokeGrant.mutate(revokeTarget.id, {
+      onSuccess: () => setRevokeTarget(null),
+    })
+  }, [revokeTarget, revokeGrant])
+
+  const handleGrantSubmit = useCallback(
+    (formData: {
+      doctorId: string
+      doctorName: string
+      reportIds: string[]
+      expiresAt: string
+    }) => {
+      createGrant.mutate(formData, {
+        onSuccess: () => setModalOpen(false),
+      })
+    },
+    [createGrant],
+  )
+
+  const isEmpty = !isLoading && grants.length === 0
+
+  return (
+    <Box maxW="1200px" mx="auto" px={{ base: '4', md: '6' }} py="6">
+      <AccessPageHeader onGrantClick={() => setModalOpen(true)} />
+
+      {/* Loading state */}
+      {isLoading && (
+        <VStack gap="3" data-testid="access-loading">
+          {[1, 2, 3].map((i) => (
+            <Skeleton
+              key={i}
+              height="80px"
+              w="full"
+              borderRadius="xl"
+            />
+          ))}
+        </VStack>
+      )}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <EmptyStateView
+          icon={
+            <svg
+              width="48"
+              height="48"
+              viewBox="0 0 48 48"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinejoin="round"
+            >
+              <path d="M24 4 L42 12 L42 26 C42 36 33 43 24 46 C15 43 6 36 6 26 L6 12 Z" />
+              <path
+                d="M17 24 L22 29 L31 19"
+                strokeLinecap="round"
+              />
+            </svg>
+          }
+          title="No active grants"
+          description="Grant a doctor access to your reports"
+          action={{
+            label: 'Grant Access',
+            onClick: () => setModalOpen(true),
+          }}
+        />
+      )}
+
+      {/* Active grants */}
+      {!isLoading && activeGrants.length > 0 && (
+        <Box mb="8">
+          <Heading
+            as="h2"
+            fontFamily="heading"
+            fontSize="1.15rem"
+            color="text.primary"
+            mb="4"
+          >
+            Active Grants
+          </Heading>
+          <VStack gap="3" align="stretch">
+            {activeGrants.map((grant) => (
+              <GrantCard
+                key={grant.id}
+                grant={grant}
+                onRevoke={handleRevokeClick}
+              />
+            ))}
+          </VStack>
+        </Box>
+      )}
+
+      {/* Expired grants */}
+      {!isLoading && expiredGrants.length > 0 && (
+        <Box>
+          <Heading
+            as="h2"
+            fontFamily="heading"
+            fontSize="1.15rem"
+            color="text.primary"
+            mb="4"
+          >
+            Expired Grants
+          </Heading>
+          <VStack gap="3" align="stretch">
+            {expiredGrants.map((grant) => (
+              <GrantCard
+                key={grant.id}
+                grant={grant}
+                onRevoke={handleRevokeClick}
+              />
+            ))}
+          </VStack>
+        </Box>
+      )}
+
+      {/* Grant modal */}
+      <GrantModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSubmit={handleGrantSubmit}
+        loading={createGrant.isPending}
+      />
+
+      {/* Revoke confirmation */}
+      <ConfirmDialog
+        open={revokeTarget !== null}
+        onClose={() => setRevokeTarget(null)}
+        onConfirm={handleRevokeConfirm}
+        title="Revoke Access"
+        subtitle={revokeTarget?.doctorName}
+        message="This doctor will no longer be able to view your shared reports. You can grant access again later."
+        confirmLabel="Revoke"
+        cancelLabel="Cancel"
+        destructive
+        loading={revokeGrant.isPending}
+      />
+    </Box>
+  )
 }

--- a/src/components/access/access-constants.test.ts
+++ b/src/components/access/access-constants.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getGrantStatus,
+  formatExpiryText,
+  getInitials,
+} from './access-constants'
+
+describe('getGrantStatus', () => {
+  it('returns active for grants expiring in more than 7 days', () => {
+    const future = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString()
+    const result = getGrantStatus(future)
+    expect(result.status).toBe('active')
+    expect(result.label).toBe('Active')
+    expect(result.badgeVariant).toBe('success')
+    expect(result.daysRemaining).toBeGreaterThan(7)
+  })
+
+  it('returns expiring for grants expiring in 1-7 days', () => {
+    const future = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString()
+    const result = getGrantStatus(future)
+    expect(result.status).toBe('expiring')
+    expect(result.label).toBe('Expiring Soon')
+    expect(result.badgeVariant).toBe('warning')
+    expect(result.daysRemaining).toBeGreaterThan(0)
+    expect(result.daysRemaining).toBeLessThanOrEqual(7)
+  })
+
+  it('returns expired for grants that have already expired', () => {
+    const past = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const result = getGrantStatus(past)
+    expect(result.status).toBe('expired')
+    expect(result.label).toBe('Expired')
+    expect(result.badgeVariant).toBe('pending')
+    expect(result.daysRemaining).toBeLessThanOrEqual(0)
+  })
+
+  it('returns expiring for grants expiring exactly 7 days from now', () => {
+    const exactly7 = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+    const result = getGrantStatus(exactly7)
+    expect(result.status).toBe('expiring')
+    expect(result.badgeVariant).toBe('warning')
+  })
+
+  it('returns active for grants expiring in 8 days', () => {
+    const future = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString()
+    const result = getGrantStatus(future)
+    expect(result.status).toBe('active')
+  })
+})
+
+describe('formatExpiryText', () => {
+  it('formats positive days remaining', () => {
+    expect(formatExpiryText(12)).toBe('Expires in 12 days')
+  })
+
+  it('formats singular day', () => {
+    expect(formatExpiryText(1)).toBe('Expires in 1 day')
+  })
+
+  it('formats expired days', () => {
+    expect(formatExpiryText(-5)).toBe('Expired 5 days ago')
+  })
+
+  it('formats expired today', () => {
+    expect(formatExpiryText(0)).toBe('Expired today')
+  })
+
+  it('formats singular expired day', () => {
+    expect(formatExpiryText(-1)).toBe('Expired 1 day ago')
+  })
+})
+
+describe('getInitials', () => {
+  it('extracts initials from two-word name', () => {
+    expect(getInitials('Dr. Priya')).toBe('DP')
+  })
+
+  it('extracts initials from three-word name', () => {
+    expect(getInitials('Dr. Priya Sharma')).toBe('DP')
+  })
+
+  it('limits to 2 characters', () => {
+    expect(getInitials('A B C D')).toBe('AB')
+  })
+
+  it('handles single word', () => {
+    expect(getInitials('Priya')).toBe('P')
+  })
+
+  it('handles empty string', () => {
+    expect(getInitials('')).toBe('')
+  })
+})

--- a/src/components/access/access-constants.ts
+++ b/src/components/access/access-constants.ts
@@ -1,0 +1,66 @@
+import type { StatusBadgeProps } from '@/components/ui/status-badge'
+
+export type GrantStatus = 'active' | 'expiring' | 'expired'
+
+interface GrantStatusInfo {
+  status: GrantStatus
+  label: string
+  badgeVariant: StatusBadgeProps['variant']
+  daysRemaining: number
+}
+
+export function getGrantStatus(expiresAt: string): GrantStatusInfo {
+  const now = new Date()
+  const expiry = new Date(expiresAt)
+  const diffMs = expiry.getTime() - now.getTime()
+  const daysRemaining = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+
+  if (daysRemaining <= 0) {
+    return {
+      status: 'expired',
+      label: 'Expired',
+      badgeVariant: 'pending',
+      daysRemaining,
+    }
+  }
+
+  if (daysRemaining <= 7) {
+    return {
+      status: 'expiring',
+      label: 'Expiring Soon',
+      badgeVariant: 'warning',
+      daysRemaining,
+    }
+  }
+
+  return {
+    status: 'active',
+    label: 'Active',
+    badgeVariant: 'success',
+    daysRemaining,
+  }
+}
+
+export function formatExpiryText(daysRemaining: number): string {
+  if (daysRemaining <= 0) {
+    const absDays = Math.abs(daysRemaining)
+    return absDays === 0 ? 'Expired today' : `Expired ${absDays} day${absDays === 1 ? '' : 's'} ago`
+  }
+  return `Expires in ${daysRemaining} day${daysRemaining === 1 ? '' : 's'}`
+}
+
+export function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+export const DURATION_OPTIONS = [
+  { label: '7 days', value: 7 },
+  { label: '30 days', value: 30 },
+  { label: '90 days', value: 90 },
+] as const

--- a/src/components/access/access-page-header.test.tsx
+++ b/src/components/access/access-page-header.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, userEvent } from '@/test/render'
+import { AccessPageHeader } from './access-page-header'
+
+describe('AccessPageHeader', () => {
+  it('renders the page title', () => {
+    render(<AccessPageHeader onGrantClick={vi.fn()} />)
+    expect(screen.getByRole('heading', { name: 'Doctor Access' })).toBeInTheDocument()
+  })
+
+  it('renders the Grant Access button', () => {
+    render(<AccessPageHeader onGrantClick={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /grant access/i })).toBeInTheDocument()
+  })
+
+  it('calls onGrantClick when button is clicked', async () => {
+    const onGrantClick = vi.fn()
+    render(<AccessPageHeader onGrantClick={onGrantClick} />)
+    await userEvent.click(screen.getByRole('button', { name: /grant access/i }))
+    expect(onGrantClick).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/access/access-page-header.tsx
+++ b/src/components/access/access-page-header.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { Button, Flex, Heading } from '@chakra-ui/react'
+
+export interface AccessPageHeaderProps {
+  onGrantClick: () => void
+}
+
+export function AccessPageHeader({ onGrantClick }: AccessPageHeaderProps) {
+  return (
+    <Flex
+      align="center"
+      justify="space-between"
+      mb="7"
+      flexWrap="wrap"
+      gap="3"
+    >
+      <Heading
+        as="h1"
+        fontFamily="heading"
+        fontSize={{ base: '1.4rem', md: '1.75rem' }}
+        color="text.primary"
+        letterSpacing="-0.01em"
+      >
+        Doctor Access
+      </Heading>
+      <Button
+        borderRadius="full"
+        bg="action.primary"
+        color="action.primary.text"
+        _hover={{
+          bg: 'action.primary.hover',
+          transform: 'translateY(-1px)',
+          boxShadow: '0 4px 12px rgba(14, 107, 102, 0.25)',
+        }}
+        onClick={onGrantClick}
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        >
+          <line x1="12" y1="5" x2="12" y2="19" />
+          <line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+        Grant Access
+      </Button>
+    </Flex>
+  )
+}

--- a/src/components/access/grant-card.test.tsx
+++ b/src/components/access/grant-card.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@/test/render'
+import { GrantCard } from './grant-card'
+import type { AccessGrant } from '@/types/access'
+
+function makeGrant(overrides: Partial<AccessGrant> = {}): AccessGrant {
+  return {
+    id: 'g1',
+    doctorId: 'd1',
+    doctorName: 'Dr. Priya Sharma',
+    reportIds: ['r1', 'r2', 'r3'],
+    expiresAt: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+    createdAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('GrantCard', () => {
+  it('renders doctor name and initials', () => {
+    render(<GrantCard grant={makeGrant()} onRevoke={vi.fn()} />)
+    expect(screen.getByText('Dr. Priya Sharma')).toBeInTheDocument()
+    expect(screen.getByText('DP')).toBeInTheDocument()
+  })
+
+  it('shows report count', () => {
+    render(<GrantCard grant={makeGrant()} onRevoke={vi.fn()} />)
+    expect(screen.getByText('3 reports shared')).toBeInTheDocument()
+  })
+
+  it('shows singular report count', () => {
+    render(
+      <GrantCard grant={makeGrant({ reportIds: ['r1'] })} onRevoke={vi.fn()} />,
+    )
+    expect(screen.getByText('1 report shared')).toBeInTheDocument()
+  })
+
+  it('shows Active badge for non-expiring grants', () => {
+    render(<GrantCard grant={makeGrant()} onRevoke={vi.fn()} />)
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  it('shows Expiring Soon badge for grants expiring within 7 days', () => {
+    const expiring = makeGrant({
+      expiresAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+    })
+    render(<GrantCard grant={expiring} onRevoke={vi.fn()} />)
+    expect(screen.getByText('Expiring Soon')).toBeInTheDocument()
+  })
+
+  it('shows Expired badge for past grants', () => {
+    const expired = makeGrant({
+      expiresAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    })
+    render(<GrantCard grant={expired} onRevoke={vi.fn()} />)
+    expect(screen.getByText('Expired')).toBeInTheDocument()
+  })
+
+  it('shows revoke button for active grants', () => {
+    render(<GrantCard grant={makeGrant()} onRevoke={vi.fn()} />)
+    expect(
+      screen.getByRole('button', { name: /revoke access for dr\. priya sharma/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides revoke button for expired grants', () => {
+    const expired = makeGrant({
+      expiresAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    })
+    render(<GrantCard grant={expired} onRevoke={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument()
+  })
+
+  it('calls onRevoke with grant id when revoke is clicked', async () => {
+    const onRevoke = vi.fn()
+    const { userEvent } = await import('@/test/render')
+    render(<GrantCard grant={makeGrant()} onRevoke={onRevoke} />)
+    await userEvent.click(
+      screen.getByRole('button', { name: /revoke access for dr\. priya sharma/i }),
+    )
+    expect(onRevoke).toHaveBeenCalledWith('g1')
+  })
+})

--- a/src/components/access/grant-card.tsx
+++ b/src/components/access/grant-card.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { Box, Button, Flex, Text } from '@chakra-ui/react'
+import { StatusBadge } from '@/components/ui/status-badge'
+import {
+  getGrantStatus,
+  formatExpiryText,
+  getInitials,
+} from './access-constants'
+import type { AccessGrant } from '@/types/access'
+
+export interface GrantCardProps {
+  grant: AccessGrant
+  onRevoke: (id: string) => void
+}
+
+export function GrantCard({ grant, onRevoke }: GrantCardProps) {
+  const { label, badgeVariant, daysRemaining, status } = getGrantStatus(
+    grant.expiresAt,
+  )
+  const isExpired = status === 'expired'
+  const initials = getInitials(grant.doctorName)
+  const expiryText = formatExpiryText(daysRemaining)
+  const isExpiryWarning = status === 'expiring'
+
+  return (
+    <Box
+      bg="bg.glass"
+      backdropFilter="blur(20px)"
+      borderWidth="1px"
+      borderColor="border.subtle"
+      borderRadius="xl"
+      p="5"
+      boxShadow="glass"
+      transition="transform 0.2s, box-shadow 0.2s"
+      _hover={{ transform: 'translateY(-1px)', boxShadow: 'md' }}
+      opacity={isExpired ? 0.6 : 1}
+      data-testid="grant-card"
+    >
+      <Flex align="center" gap="4" flexWrap={{ base: 'wrap', md: 'nowrap' }}>
+        {/* Avatar */}
+        <Flex
+          align="center"
+          justify="center"
+          boxSize="48px"
+          borderRadius="full"
+          flexShrink={0}
+          fontFamily="mono"
+          fontSize="0.85rem"
+          fontWeight="medium"
+          bg={isExpired ? 'border.default' : 'action.primary'}
+          color={isExpired ? 'text.muted' : 'action.primary.text'}
+        >
+          {initials}
+        </Flex>
+
+        {/* Info */}
+        <Box flex="1" minW="0">
+          <Text fontFamily="heading" fontSize="1.05rem" color="text.primary" lineHeight="1.3">
+            {grant.doctorName}
+          </Text>
+          <Flex align="center" gap="4" mt="1.5" flexWrap="wrap">
+            <Text
+              fontFamily="mono"
+              fontSize="0.78rem"
+              color="text.secondary"
+            >
+              {grant.reportIds.length} report{grant.reportIds.length === 1 ? '' : 's'} shared
+            </Text>
+            <Text
+              fontFamily="mono"
+              fontSize="0.78rem"
+              color={isExpiryWarning ? 'amber.400' : 'text.muted'}
+            >
+              {expiryText}
+            </Text>
+          </Flex>
+        </Box>
+
+        {/* Actions */}
+        <Flex
+          align="center"
+          gap="3"
+          flexShrink={0}
+          w={{ base: '100%', md: 'auto' }}
+          justify={{ base: 'flex-end', md: 'flex-start' }}
+          mt={{ base: '1', md: '0' }}
+        >
+          <StatusBadge variant={badgeVariant}>{label}</StatusBadge>
+          {!isExpired && (
+            <Button
+              variant="outline"
+              size="sm"
+              borderRadius="full"
+              borderColor="coral.400"
+              color="coral.400"
+              _hover={{ bg: 'rgba(255, 107, 107, 0.08)' }}
+              onClick={() => onRevoke(grant.id)}
+              aria-label={`Revoke access for ${grant.doctorName}`}
+            >
+              Revoke
+            </Button>
+          )}
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/components/access/grant-modal.test.tsx
+++ b/src/components/access/grant-modal.test.tsx
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, userEvent, waitFor } from '@/test/render'
+import { GrantModal } from './grant-modal'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const mockDoctors = {
+  items: [
+    {
+      id: 'doc1',
+      name: 'Dr. Arun Mehta',
+      specialisation: 'Orthopedic',
+      registrationNumber: 'MH12345',
+    },
+    {
+      id: 'doc2',
+      name: 'Dr. Priya Sharma',
+      specialisation: 'Cardiologist',
+      registrationNumber: 'MH67890',
+    },
+  ],
+}
+
+const mockReports = {
+  items: [
+    {
+      id: 'r1',
+      title: 'Complete Blood Count',
+      reportType: 'lab',
+      status: 'verified',
+      reportDate: '2025-01-15T00:00:00Z',
+      labName: 'Thyrocare',
+      doctorName: null,
+      notes: null,
+      highlightParameter: null,
+      createdAt: '2025-01-15T10:00:00Z',
+      updatedAt: '2025-01-15T10:00:00Z',
+    },
+    {
+      id: 'r2',
+      title: 'Chest X-Ray',
+      reportType: 'imaging',
+      status: 'verified',
+      reportDate: '2025-02-10T00:00:00Z',
+      labName: null,
+      doctorName: null,
+      notes: null,
+      highlightParameter: null,
+      createdAt: '2025-02-10T10:00:00Z',
+      updatedAt: '2025-02-10T10:00:00Z',
+    },
+  ],
+  page: 1,
+  pageSize: 100,
+  totalCount: 2,
+  totalPages: 1,
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  mockFetch.mockImplementation((url: string) => {
+    if (url.includes('/v1/doctors/search')) return Promise.resolve(jsonResponse(mockDoctors))
+    if (url.includes('/v1/reports')) return Promise.resolve(jsonResponse(mockReports))
+    return Promise.resolve(jsonResponse({}))
+  })
+})
+
+describe('GrantModal', () => {
+  it('renders modal title and subtitle when open', () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+    expect(screen.getByText('Grant Doctor Access')).toBeInTheDocument()
+    expect(
+      screen.getByText('Search for a doctor and choose which reports to share.'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows search input on initial open', () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+    expect(screen.getByPlaceholderText('Search by name or ID...')).toBeInTheDocument()
+  })
+
+  it('shows step 1 label', () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+    expect(screen.getByText(/step 1/i)).toBeInTheDocument()
+  })
+
+  it('shows doctor search results after typing', async () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+
+    const searchInput = screen.getByPlaceholderText('Search by name or ID...')
+    await userEvent.type(searchInput, 'Dr. Ar')
+
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+    expect(screen.getAllByTestId('doctor-search-result')).toHaveLength(2)
+  })
+
+  it('shows report selection after selecting a doctor', async () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+
+    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+
+    // Select the doctor
+    const selectButtons = screen.getAllByRole('button', { name: 'Select' })
+    await userEvent.click(selectButtons[0])
+
+    // Should show report selection
+    await waitFor(() => {
+      expect(screen.getByText(/step 2/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText('Complete Blood Count')).toBeInTheDocument()
+    expect(screen.getByText('Chest X-Ray')).toBeInTheDocument()
+  })
+
+  it('shows duration picker after selecting reports', async () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+
+    // Search and select doctor
+    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+
+    // Select a report
+    await waitFor(() => {
+      expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
+    })
+    await userEvent.click(screen.getAllByTestId('report-checkbox')[0])
+
+    // Duration picker should appear
+    await waitFor(() => {
+      expect(screen.getByText(/step 3/i)).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: '7 days' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '30 days' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '90 days' })).toBeInTheDocument()
+  })
+
+  it('shows Change button after selecting a doctor', async () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+
+    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+
+    expect(screen.getByRole('button', { name: /change doctor/i })).toBeInTheDocument()
+  })
+
+  it('calls onSubmit with correct data on form completion', async () => {
+    const onSubmit = vi.fn()
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={onSubmit} />,
+    )
+
+    // Step 1: Select doctor
+    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+
+    // Step 2: Select report
+    await waitFor(() => {
+      expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
+    })
+    await userEvent.click(screen.getAllByTestId('report-checkbox')[0])
+
+    // Step 3: Duration (30 days is default)
+    // Submit
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /grant access$/i })).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByRole('button', { name: /grant access$/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        doctorId: 'doc1',
+        doctorName: 'Dr. Arun Mehta',
+        reportIds: ['r1'],
+        expiresAt: expect.any(String),
+      }),
+    )
+  })
+
+  it('does not render modal content when closed', () => {
+    render(
+      <GrantModal open={false} onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+    expect(screen.queryByText('Grant Doctor Access')).not.toBeInTheDocument()
+  })
+
+  it('shows empty message when no reports available', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/v1/doctors/search')) return Promise.resolve(jsonResponse(mockDoctors))
+      if (url.includes('/v1/reports')) {
+        return Promise.resolve(
+          jsonResponse({ items: [], page: 1, pageSize: 100, totalCount: 0, totalPages: 0 }),
+        )
+      }
+      return Promise.resolve(jsonResponse({}))
+    })
+
+    render(<GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />)
+
+    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+
+    await waitFor(() => {
+      expect(screen.getByText('No reports available to share.')).toBeInTheDocument()
+    })
+  })
+
+  it('allows custom duration input', async () => {
+    const onSubmit = vi.fn()
+    render(<GrantModal open onClose={vi.fn()} onSubmit={onSubmit} />)
+
+    // Step 1: Select doctor
+    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+
+    // Step 2: Select report
+    await waitFor(() => {
+      expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
+    })
+    await userEvent.click(screen.getAllByTestId('report-checkbox')[0])
+
+    // Step 3: Enter custom duration
+    await waitFor(() => {
+      expect(screen.getByLabelText('Custom duration in days')).toBeInTheDocument()
+    })
+    await userEvent.type(screen.getByLabelText('Custom duration in days'), '45')
+
+    // Submit
+    await userEvent.click(screen.getByRole('button', { name: /grant access$/i }))
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        doctorId: 'doc1',
+        reportIds: ['r1'],
+      }),
+    )
+  })
+
+  it('allows selecting a different duration preset', async () => {
+    render(<GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />)
+
+    // Step 1: Select doctor
+    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+
+    // Step 2: Select report
+    await waitFor(() => {
+      expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
+    })
+    await userEvent.click(screen.getAllByTestId('report-checkbox')[0])
+
+    // Step 3: Click 7 days
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '7 days' })).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByRole('button', { name: '7 days' }))
+
+    // Submit button should still be visible
+    expect(screen.getByRole('button', { name: /grant access$/i })).toBeInTheDocument()
+  })
+
+  it('can deselect a report to remove it', async () => {
+    render(<GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />)
+
+    // Step 1: Select doctor
+    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+
+    // Step 2: Select then deselect a report
+    await waitFor(() => {
+      expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
+    })
+    const firstCheckbox = screen.getAllByTestId('report-checkbox')[0]
+    await userEvent.click(firstCheckbox)
+
+    // Duration should appear
+    await waitFor(() => {
+      expect(screen.getByText(/step 3/i)).toBeInTheDocument()
+    })
+
+    // Deselect
+    await userEvent.click(firstCheckbox)
+
+    // Duration should disappear (no reports selected)
+    await waitFor(() => {
+      expect(screen.queryByText(/step 3/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('resets state when dialog is closed', async () => {
+    const onClose = vi.fn()
+    render(<GrantModal open onClose={onClose} onSubmit={vi.fn()} />)
+
+    // Type in search
+    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+    })
+
+    // Select doctor
+    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+    expect(screen.getByRole('button', { name: /change doctor/i })).toBeInTheDocument()
+  })
+})

--- a/src/components/access/grant-modal.tsx
+++ b/src/components/access/grant-modal.tsx
@@ -1,0 +1,535 @@
+'use client'
+
+import { useState, useCallback, useMemo } from 'react'
+import {
+  Box,
+  Button,
+  DialogRoot,
+  DialogBackdrop,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogPositioner,
+  Flex,
+  Input,
+  Skeleton,
+  Text,
+} from '@chakra-ui/react'
+import { useSearchDoctors } from '@/hooks/access'
+import { useReports } from '@/hooks/reports'
+import { DURATION_OPTIONS, getInitials } from './access-constants'
+import type { Doctor } from '@/types/access'
+
+export interface GrantModalProps {
+  open: boolean
+  onClose: () => void
+  onSubmit: (data: {
+    doctorId: string
+    doctorName: string
+    reportIds: string[]
+    expiresAt: string
+  }) => void
+  loading?: boolean
+}
+
+type Step = 'search' | 'reports' | 'duration'
+
+export function GrantModal({ open, onClose, onSubmit, loading = false }: GrantModalProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedDoctor, setSelectedDoctor] = useState<Doctor | null>(null)
+  const [selectedReportIds, setSelectedReportIds] = useState<Set<string>>(new Set())
+  const [selectedDuration, setSelectedDuration] = useState<number | null>(30)
+  const [customDays, setCustomDays] = useState('')
+
+  const doctorSearch = useSearchDoctors(searchQuery)
+  const { data: reportsData, isLoading: reportsLoading } = useReports({ pageSize: 100 })
+
+  const currentStep: Step = !selectedDoctor
+    ? 'search'
+    : selectedReportIds.size === 0
+      ? 'reports'
+      : 'duration'
+
+  const effectiveDays = selectedDuration ?? (customDays ? parseInt(customDays, 10) : 0)
+  const canSubmit =
+    selectedDoctor !== null &&
+    selectedReportIds.size > 0 &&
+    effectiveDays > 0 &&
+    !loading
+
+  const handleSelectDoctor = useCallback((doctor: Doctor) => {
+    setSelectedDoctor(doctor)
+  }, [])
+
+  const toggleReport = useCallback((reportId: string) => {
+    setSelectedReportIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(reportId)) {
+        next.delete(reportId)
+      } else {
+        next.add(reportId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleDurationSelect = useCallback((days: number) => {
+    setSelectedDuration(days)
+    setCustomDays('')
+  }, [])
+
+  const handleCustomDaysChange = useCallback((value: string) => {
+    setCustomDays(value)
+    setSelectedDuration(null)
+  }, [])
+
+  const handleSubmit = useCallback(() => {
+    if (!selectedDoctor || !canSubmit) return
+    const expiresAt = new Date(
+      Date.now() + effectiveDays * 24 * 60 * 60 * 1000,
+    ).toISOString()
+    onSubmit({
+      doctorId: selectedDoctor.id,
+      doctorName: selectedDoctor.name,
+      reportIds: Array.from(selectedReportIds),
+      expiresAt,
+    })
+  }, [selectedDoctor, selectedReportIds, effectiveDays, canSubmit, onSubmit])
+
+  const handleClose = useCallback(() => {
+    setSearchQuery('')
+    setSelectedDoctor(null)
+    setSelectedReportIds(new Set())
+    setSelectedDuration(30)
+    setCustomDays('')
+    onClose()
+  }, [onClose])
+
+  const reports = useMemo(() => reportsData?.items ?? [], [reportsData])
+
+  return (
+    <DialogRoot
+      open={open}
+      onOpenChange={(details) => !details.open && handleClose()}
+    >
+      <DialogBackdrop />
+      <DialogPositioner>
+        <DialogContent
+          bg="bg.glass"
+          backdropFilter="blur(24px)"
+          borderColor="border.subtle"
+          borderWidth="1px"
+          boxShadow="glass"
+          borderRadius="2xl"
+          maxW="520px"
+          w="full"
+          mx="4"
+        >
+          <DialogHeader>
+            <DialogTitle fontFamily="heading" fontSize="1.3rem" color="text.primary">
+              Grant Doctor Access
+            </DialogTitle>
+            <Text fontSize="0.88rem" color="text.muted" mt="1">
+              Search for a doctor and choose which reports to share.
+            </Text>
+          </DialogHeader>
+          <DialogBody pb="6">
+            {/* Step 1: Search Doctor */}
+            <StepLabel
+              step={1}
+              label="Search Doctor"
+              active={currentStep === 'search'}
+            />
+            {!selectedDoctor ? (
+              <DoctorSearch
+                query={searchQuery}
+                onQueryChange={setSearchQuery}
+                results={doctorSearch.data?.items ?? []}
+                isLoading={doctorSearch.isLoading}
+                onSelect={handleSelectDoctor}
+              />
+            ) : (
+              <SelectedDoctorBadge
+                doctor={selectedDoctor}
+                onClear={() => setSelectedDoctor(null)}
+              />
+            )}
+
+            {/* Step 2: Select Reports */}
+            {selectedDoctor && (
+              <>
+                <StepLabel
+                  step={2}
+                  label="Select Reports"
+                  active={currentStep === 'reports'}
+                />
+                <ReportSelector
+                  reports={reports}
+                  selectedIds={selectedReportIds}
+                  onToggle={toggleReport}
+                  loading={reportsLoading}
+                />
+              </>
+            )}
+
+            {/* Step 3: Set Duration */}
+            {selectedDoctor && selectedReportIds.size > 0 && (
+              <>
+                <StepLabel
+                  step={3}
+                  label="Set Duration"
+                  active={currentStep === 'duration'}
+                />
+                <DurationPicker
+                  selected={selectedDuration}
+                  customDays={customDays}
+                  onSelect={handleDurationSelect}
+                  onCustomChange={handleCustomDaysChange}
+                />
+              </>
+            )}
+
+            {/* Submit */}
+            {selectedDoctor && selectedReportIds.size > 0 && (
+              <Button
+                w="full"
+                borderRadius="full"
+                bg="action.primary"
+                color="action.primary.text"
+                mt="5"
+                _hover={{
+                  bg: 'action.primary.hover',
+                  transform: 'translateY(-1px)',
+                  boxShadow: '0 4px 12px rgba(14, 107, 102, 0.25)',
+                }}
+                onClick={handleSubmit}
+                loading={loading}
+                disabled={!canSubmit}
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                </svg>
+                Grant Access
+              </Button>
+            )}
+          </DialogBody>
+        </DialogContent>
+      </DialogPositioner>
+    </DialogRoot>
+  )
+}
+
+/* ── Sub-components ── */
+
+function StepLabel({ step, label, active }: { step: number; label: string; active: boolean }) {
+  return (
+    <Text
+      fontFamily="mono"
+      fontSize="0.72rem"
+      fontWeight="medium"
+      letterSpacing="0.1em"
+      textTransform="uppercase"
+      color={active ? 'text.secondary' : 'text.muted'}
+      mt={step === 1 ? '0' : '6'}
+      mb="2.5"
+    >
+      Step {step} &mdash; {label}
+    </Text>
+  )
+}
+
+function DoctorSearch({
+  query,
+  onQueryChange,
+  results,
+  isLoading,
+  onSelect,
+}: {
+  query: string
+  onQueryChange: (q: string) => void
+  results: Doctor[]
+  isLoading: boolean
+  onSelect: (doctor: Doctor) => void
+}) {
+  return (
+    <Box>
+      <Box position="relative" mb="3">
+        <Box
+          position="absolute"
+          left="14px"
+          top="50%"
+          transform="translateY(-50%)"
+          color="text.muted"
+          zIndex="1"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+        </Box>
+        <Input
+          pl="42px"
+          bg="bg.glass"
+          backdropFilter="blur(12px)"
+          borderColor="border.default"
+          borderRadius="xl"
+          fontSize="0.9rem"
+          placeholder="Search by name or ID..."
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          aria-label="Search doctors"
+        />
+      </Box>
+      {isLoading && query.length >= 2 && (
+        <Box display="flex" flexDirection="column" gap="2">
+          {[1, 2].map((i) => (
+            <Skeleton key={i} height="60px" borderRadius="xl" />
+          ))}
+        </Box>
+      )}
+      {!isLoading &&
+        results.map((doctor) => (
+          <Flex
+            key={doctor.id}
+            align="center"
+            gap="3"
+            p="3"
+            borderWidth="1px"
+            borderColor="border.subtle"
+            borderRadius="xl"
+            mb="2"
+            bg="bg.overlay"
+            _hover={{ bg: 'border.subtle' }}
+            transition="background 0.2s"
+            data-testid="doctor-search-result"
+          >
+            <Flex
+              align="center"
+              justify="center"
+              boxSize="40px"
+              borderRadius="full"
+              bg="action.primary"
+              color="action.primary.text"
+              fontFamily="mono"
+              fontSize="0.78rem"
+              fontWeight="medium"
+              flexShrink={0}
+            >
+              {getInitials(doctor.name)}
+            </Flex>
+            <Box flex="1" minW="0">
+              <Text fontFamily="heading" fontSize="0.95rem" color="text.primary">
+                {doctor.name}
+              </Text>
+              <Text fontSize="0.8rem" color="text.muted">
+                {doctor.specialisation}
+              </Text>
+            </Box>
+            <Button
+              size="sm"
+              borderRadius="full"
+              bg="action.primary"
+              color="action.primary.text"
+              onClick={() => onSelect(doctor)}
+            >
+              Select
+            </Button>
+          </Flex>
+        ))}
+    </Box>
+  )
+}
+
+function SelectedDoctorBadge({
+  doctor,
+  onClear,
+}: {
+  doctor: Doctor
+  onClear: () => void
+}) {
+  return (
+    <Flex
+      align="center"
+      gap="3"
+      p="3"
+      borderWidth="1px"
+      borderColor="action.primary"
+      borderRadius="xl"
+      bg="bg.overlay"
+    >
+      <Flex
+        align="center"
+        justify="center"
+        boxSize="40px"
+        borderRadius="full"
+        bg="action.primary"
+        color="action.primary.text"
+        fontFamily="mono"
+        fontSize="0.78rem"
+        fontWeight="medium"
+        flexShrink={0}
+      >
+        {getInitials(doctor.name)}
+      </Flex>
+      <Box flex="1" minW="0">
+        <Text fontFamily="heading" fontSize="0.95rem" color="text.primary">
+          {doctor.name}
+        </Text>
+        <Text fontSize="0.8rem" color="text.muted">
+          {doctor.specialisation}
+        </Text>
+      </Box>
+      <Button
+        variant="ghost"
+        size="sm"
+        borderRadius="full"
+        onClick={onClear}
+        aria-label="Change doctor"
+      >
+        Change
+      </Button>
+    </Flex>
+  )
+}
+
+function ReportSelector({
+  reports,
+  selectedIds,
+  onToggle,
+  loading,
+}: {
+  reports: { id: string; title: string; reportDate: string }[]
+  selectedIds: Set<string>
+  onToggle: (id: string) => void
+  loading: boolean
+}) {
+  if (loading) {
+    return (
+      <Box display="flex" flexDirection="column" gap="2">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} height="44px" borderRadius="lg" />
+        ))}
+      </Box>
+    )
+  }
+
+  if (reports.length === 0) {
+    return (
+      <Text fontSize="0.88rem" color="text.muted" textAlign="center" py="4">
+        No reports available to share.
+      </Text>
+    )
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" gap="2">
+      {reports.map((report) => (
+        <Box
+          as="label"
+          key={report.id}
+          display="flex"
+          alignItems="center"
+          gap="2.5"
+          px="3"
+          py="2.5"
+          borderWidth="1px"
+          borderColor="border.subtle"
+          borderRadius="lg"
+          bg="bg.overlay"
+          cursor="pointer"
+          transition="background 0.2s"
+          _hover={{ bg: 'border.subtle' }}
+          data-testid="report-checkbox"
+        >
+          <input
+            type="checkbox"
+            checked={selectedIds.has(report.id)}
+            onChange={() => onToggle(report.id)}
+            style={{ width: 18, height: 18, accentColor: 'var(--chakra-colors-brand-500)' }}
+          />
+          <Text flex="1" fontSize="0.88rem" color="text.primary">
+            {report.title}
+          </Text>
+          <Text fontFamily="mono" fontSize="0.75rem" color="text.muted" flexShrink={0}>
+            {new Date(report.reportDate).toLocaleDateString('en-IN', {
+              day: 'numeric',
+              month: 'short',
+              year: 'numeric',
+            })}
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+function DurationPicker({
+  selected,
+  customDays,
+  onSelect,
+  onCustomChange,
+}: {
+  selected: number | null
+  customDays: string
+  onSelect: (days: number) => void
+  onCustomChange: (value: string) => void
+}) {
+  return (
+    <Box>
+      <Flex gap="2" mb="3" flexWrap="wrap">
+        {DURATION_OPTIONS.map((opt) => (
+          <Button
+            key={opt.value}
+            borderRadius="full"
+            size="sm"
+            variant={selected === opt.value ? 'solid' : 'outline'}
+            bg={selected === opt.value ? 'action.primary' : 'transparent'}
+            color={selected === opt.value ? 'action.primary.text' : 'text.secondary'}
+            borderColor="border.default"
+            onClick={() => onSelect(opt.value)}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </Flex>
+      <Flex align="center" gap="2">
+        <Input
+          type="number"
+          placeholder="45"
+          value={customDays}
+          onChange={(e) => onCustomChange(e.target.value)}
+          w="80px"
+          bg="bg.glass"
+          borderColor="border.default"
+          borderRadius="lg"
+          fontFamily="mono"
+          fontSize="0.85rem"
+          textAlign="center"
+          aria-label="Custom duration in days"
+        />
+        <Text fontSize="0.85rem" color="text.muted">
+          days
+        </Text>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/components/access/index.ts
+++ b/src/components/access/index.ts
@@ -1,0 +1,4 @@
+export { AccessPageHeader } from './access-page-header'
+export { GrantCard } from './grant-card'
+export { GrantModal } from './grant-modal'
+export { getGrantStatus, formatExpiryText, getInitials } from './access-constants'


### PR DESCRIPTION
## Summary
- Implements the doctor access grants page with active/expired grants list, grant creation flow, and revoke confirmation
- Grant cards display doctor avatar, name, reports shared count, expiry status (Active/Expiring Soon/Expired), and revoke action
- 3-step grant modal wizard: doctor search (debounced autocomplete) → report selection (multi-select) → duration picker (preset + custom)
- Empty state with CTA when no grants exist
- Loading skeleton states for initial data fetch
- Revoke flow with ConfirmDialog and optimistic updates

## Test plan
- [x] 15 unit tests for utility functions (getGrantStatus, formatExpiryText, getInitials)
- [x] 9 component tests for GrantCard (status badges, revoke button, expired state)
- [x] 3 component tests for AccessPageHeader
- [x] 14 component tests for GrantModal (search → select → duration → submit flow, empty reports, custom duration, deselect)
- [x] 11 integration tests for AccessPage (loading, empty state, active/expired sections, revoke dialog, grant modal)
- [x] All 573 tests pass, 0 failures
- [x] TypeScript strict mode — no errors
- [x] ESLint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)