### PR TITLE
Add emergency contacts page with CRUD and optimistic updates (#22)

### DIFF
--- a/src/app/(portal)/emergency/page.test.tsx
+++ b/src/app/(portal)/emergency/page.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, userEvent, waitFor } from '@/test/render'
+import EmergencyPage from './page'
+import type { EmergencyContactListResponse } from '@/types/emergency'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const contact1 = {
+  id: 'ec1',
+  name: 'Priya Sharma',
+  phone: '9876543210',
+  relationship: 'spouse' as const,
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+}
+
+const contact2 = {
+  id: 'ec2',
+  name: 'Rajesh Kumar',
+  phone: '9123456789',
+  relationship: 'parent' as const,
+  createdAt: '2025-01-05T00:00:00Z',
+  updatedAt: '2025-01-05T00:00:00Z',
+}
+
+const contact3 = {
+  id: 'ec3',
+  name: 'Anita Desai',
+  phone: '8765432109',
+  relationship: 'sibling' as const,
+  createdAt: '2025-01-10T00:00:00Z',
+  updatedAt: '2025-01-10T00:00:00Z',
+}
+
+const mockContacts: EmergencyContactListResponse = {
+  items: [contact1, contact2],
+}
+
+const fullContacts: EmergencyContactListResponse = {
+  items: [contact1, contact2, contact3],
+}
+
+const emptyContacts: EmergencyContactListResponse = {
+  items: [],
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('EmergencyPage', () => {
+  it('shows loading skeleton on initial render', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}))
+    render(<EmergencyPage />)
+    expect(screen.getByTestId('emergency-loading')).toBeInTheDocument()
+  })
+
+  it('renders page heading and Add Contact button', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    expect(screen.getByRole('heading', { name: 'Emergency Contacts' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add contact/i })).toBeInTheDocument()
+  })
+
+  it('renders contact cards after loading', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Priya Sharma')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Rajesh Kumar')).toBeInTheDocument()
+    expect(screen.getAllByTestId('contact-card')).toHaveLength(2)
+  })
+
+  it('shows callout banner when contacts exist', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/emergency medical profile/),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no contacts exist', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(emptyContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No emergency contacts')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('Add people who should be contacted in case of emergency'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows dashed add-card with remaining count', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('add-contact-card')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/1 remaining/)).toBeInTheDocument()
+  })
+
+  it('hides dashed add-card when at limit', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(fullContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Priya Sharma')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('add-contact-card')).not.toBeInTheDocument()
+  })
+
+  it('shows maximum contacts hint', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/maximum 3 emergency contacts/i)).toBeInTheDocument()
+    })
+  })
+
+  it('opens add modal when Add Contact button is clicked', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Priya Sharma')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /add contact/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Emergency Contact')).toBeInTheDocument()
+    })
+  })
+
+  it('opens add modal from empty state CTA', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(emptyContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No emergency contacts')).toBeInTheDocument()
+    })
+
+    const buttons = screen.getAllByRole('button', { name: /add contact/i })
+    await userEvent.click(buttons[buttons.length - 1])
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Emergency Contact')).toBeInTheDocument()
+    })
+  })
+
+  it('opens add modal from dashed card', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('add-contact-card')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByTestId('add-contact-card'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Emergency Contact')).toBeInTheDocument()
+    })
+  })
+
+  it('opens edit modal when Edit is clicked on a contact', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Priya Sharma')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /edit priya sharma/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Emergency Contact')).toBeInTheDocument()
+    })
+    expect(screen.getByPlaceholderText('Enter full name')).toHaveValue('Priya Sharma')
+  })
+
+  it('opens delete dialog when Remove is clicked', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Priya Sharma')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /remove priya sharma/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Remove Contact')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText(/will no longer be listed/),
+    ).toBeInTheDocument()
+  })
+
+  it('confirms delete and sends DELETE request', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Priya Sharma')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /remove priya sharma/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Remove Contact')).toBeInTheDocument()
+    })
+
+    mockFetch.mockResolvedValue(jsonResponse(null, 200))
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => {
+      const calls = mockFetch.mock.calls
+      const deleteCall = calls.find((call) => {
+        const url = call[0] as string
+        return url.includes('/v1/emergency-contacts/ec1')
+      })
+      expect(deleteCall).toBeTruthy()
+    })
+  })
+
+  it('closes delete dialog when Cancel is clicked', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Priya Sharma')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /remove priya sharma/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Remove Contact')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => {
+      expect(screen.queryByText(/will no longer be listed/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('submits add form with POST request', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockContacts))
+    render(<EmergencyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Priya Sharma')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /add contact/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Add Emergency Contact')).toBeInTheDocument()
+    })
+
+    await userEvent.type(screen.getByPlaceholderText('Enter full name'), 'New Person')
+    await userEvent.type(screen.getByPlaceholderText('Enter phone number'), '9999988888')
+
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        id: 'ec-new',
+        name: 'New Person',
+        phone: '9999988888',
+        relationship: 'spouse',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save Contact' }))
+
+    await waitFor(() => {
+      const calls = mockFetch.mock.calls
+      const postCall = calls.find((call) => {
+        const opts = call[1] as RequestInit | undefined
+        return opts?.method === 'POST'
+      })
+      expect(postCall).toBeTruthy()
+    })
+  })
+})

--- a/src/app/(portal)/emergency/page.tsx
+++ b/src/app/(portal)/emergency/page.tsx
@@ -1,3 +1,286 @@
+'use client'
+
+import { useState, useMemo, useCallback } from 'react'
+import { Box, Button, Flex, Heading, Skeleton, Text, Tooltip, VStack } from '@chakra-ui/react'
+import {
+  useEmergencyContacts,
+  useCreateEmergencyContact,
+  useUpdateEmergencyContact,
+  useDeleteEmergencyContact,
+} from '@/hooks/emergency'
+import { ContactCard, ContactModal, MAX_CONTACTS } from '@/components/emergency'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { EmptyStateView } from '@/components/ui/empty-state'
+import type { EmergencyContact } from '@/types/emergency'
+import type { EmergencyContact as EmergencyContactFormData } from '@/lib/schemas/emergencyContact'
+
 export default function EmergencyPage() {
-  return <div>Emergency Contacts</div>
+  const { data, isLoading } = useEmergencyContacts()
+  const createContact = useCreateEmergencyContact()
+  const updateContact = useUpdateEmergencyContact()
+  const deleteContact = useDeleteEmergencyContact()
+
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<EmergencyContact | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<EmergencyContact | null>(null)
+
+  const contacts = useMemo(() => data?.items ?? [], [data])
+  const isAtLimit = contacts.length >= MAX_CONTACTS
+  const isEmpty = !isLoading && contacts.length === 0
+
+  const handleAddClick = useCallback(() => {
+    setEditTarget(null)
+    setModalOpen(true)
+  }, [])
+
+  const handleEditClick = useCallback(
+    (id: string) => {
+      const contact = contacts.find((c) => c.id === id)
+      if (contact) {
+        setEditTarget(contact)
+        setModalOpen(true)
+      }
+    },
+    [contacts],
+  )
+
+  const handleDeleteClick = useCallback(
+    (id: string) => {
+      const contact = contacts.find((c) => c.id === id)
+      if (contact) setDeleteTarget(contact)
+    },
+    [contacts],
+  )
+
+  const handleModalSubmit = useCallback(
+    (formData: EmergencyContactFormData) => {
+      if (editTarget) {
+        updateContact.mutate(
+          { id: editTarget.id, ...formData },
+          { onSuccess: () => setModalOpen(false) },
+        )
+      } else {
+        createContact.mutate(formData, {
+          onSuccess: () => setModalOpen(false),
+        })
+      }
+    },
+    [editTarget, createContact, updateContact],
+  )
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (!deleteTarget) return
+    deleteContact.mutate(deleteTarget.id, {
+      onSuccess: () => setDeleteTarget(null),
+    })
+  }, [deleteTarget, deleteContact])
+
+  return (
+    <Box maxW="1200px" mx="auto" px={{ base: '4', md: '6' }} py="6">
+      {/* Header */}
+      <Flex align="center" justify="space-between" mb="5" flexWrap="wrap" gap="3">
+        <Heading
+          as="h1"
+          fontFamily="heading"
+          fontSize={{ base: '1.4rem', md: '1.75rem' }}
+          color="text.primary"
+          letterSpacing="-0.01em"
+        >
+          Emergency Contacts
+        </Heading>
+        <Tooltip.Root disabled={!isAtLimit}>
+          <Tooltip.Trigger asChild>
+            <Button
+              borderRadius="full"
+              bg="action.primary"
+              color="action.primary.text"
+              _hover={{
+                bg: 'action.primary.hover',
+                transform: 'translateY(-1px)',
+                boxShadow: '0 4px 12px rgba(14, 107, 102, 0.25)',
+              }}
+              onClick={handleAddClick}
+              disabled={isAtLimit}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+              >
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              Add Contact
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Positioner>
+            <Tooltip.Content>
+              Maximum {MAX_CONTACTS} contacts allowed
+            </Tooltip.Content>
+          </Tooltip.Positioner>
+        </Tooltip.Root>
+      </Flex>
+
+      {/* Callout banner */}
+      {!isEmpty && !isLoading && (
+        <Flex
+          align="flex-start"
+          gap="3"
+          px="4"
+          py="3"
+          borderRadius="xl"
+          mb="6"
+          bg="rgba(255, 179, 71, 0.12)"
+          borderWidth="1px"
+          borderColor="rgba(255, 179, 71, 0.25)"
+          css={{
+            _dark: {
+              bg: 'rgba(255, 179, 71, 0.08)',
+              borderColor: 'rgba(255, 179, 71, 0.18)',
+            },
+          }}
+        >
+          <Box flexShrink={0} mt="0.5" color="amber.400">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+              <line x1="12" y1="9" x2="12" y2="13" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          </Box>
+          <Text fontSize="0.88rem" fontWeight="medium" color="text.secondary" lineHeight="1.5">
+            These contacts can access your emergency medical profile if you are incapacitated.
+          </Text>
+        </Flex>
+      )}
+
+      {/* Loading */}
+      {isLoading && (
+        <VStack gap="3" data-testid="emergency-loading">
+          {[1, 2].map((i) => (
+            <Skeleton key={i} height="80px" w="full" borderRadius="xl" />
+          ))}
+        </VStack>
+      )}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <EmptyStateView
+          icon={
+            <svg
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
+            </svg>
+          }
+          title="No emergency contacts"
+          description="Add people who should be contacted in case of emergency"
+          action={{
+            label: 'Add Contact',
+            onClick: handleAddClick,
+          }}
+        />
+      )}
+
+      {/* Contact list */}
+      {!isLoading && contacts.length > 0 && (
+        <VStack gap="3" align="stretch">
+          {contacts.map((contact) => (
+            <ContactCard
+              key={contact.id}
+              contact={contact}
+              onEdit={handleEditClick}
+              onDelete={handleDeleteClick}
+            />
+          ))}
+
+          {/* Add contact card (dashed) */}
+          {!isAtLimit && (
+            <Box
+              border="2px dashed"
+              borderColor="border.default"
+              borderRadius="xl"
+              py="7"
+              px="5"
+              display="flex"
+              flexDirection="column"
+              alignItems="center"
+              gap="2"
+              cursor="pointer"
+              transition="all 0.25s"
+              _hover={{ borderColor: 'action.primary', bg: 'bg.overlay' }}
+              onClick={handleAddClick}
+              role="button"
+              aria-label="Add emergency contact"
+              data-testid="add-contact-card"
+            >
+              <svg
+                width="32"
+                height="32"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                style={{ color: 'var(--chakra-colors-text-muted)' }}
+              >
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              <Text fontSize="0.88rem" color="text.muted" fontWeight="medium">
+                Add emergency contact ({MAX_CONTACTS - contacts.length} remaining)
+              </Text>
+            </Box>
+          )}
+
+          {/* Hint */}
+          <Text fontFamily="mono" fontSize="0.75rem" color="text.muted" mt="1">
+            Maximum {MAX_CONTACTS} emergency contacts allowed
+          </Text>
+        </VStack>
+      )}
+
+      {/* Add/Edit modal */}
+      <ContactModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSubmit={handleModalSubmit}
+        loading={editTarget ? updateContact.isPending : createContact.isPending}
+        initialData={editTarget}
+      />
+
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Remove Contact"
+        subtitle={deleteTarget?.name}
+        message="This person will no longer be listed as your emergency contact. You can add them back later."
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        destructive
+        loading={deleteContact.isPending}
+      />
+    </Box>
+  )
 }

--- a/src/components/emergency/contact-card.test.tsx
+++ b/src/components/emergency/contact-card.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, userEvent } from '@/test/render'
+import { ContactCard } from './contact-card'
+import type { EmergencyContact } from '@/types/emergency'
+
+function makeContact(overrides: Partial<EmergencyContact> = {}): EmergencyContact {
+  return {
+    id: 'ec1',
+    name: 'Priya Sharma',
+    phone: '9876543210',
+    relationship: 'spouse',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ContactCard', () => {
+  it('renders contact name and initials', () => {
+    render(<ContactCard contact={makeContact()} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('Priya Sharma')).toBeInTheDocument()
+    expect(screen.getByText('PS')).toBeInTheDocument()
+  })
+
+  it('shows relationship badge', () => {
+    render(<ContactCard contact={makeContact()} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('Spouse')).toBeInTheDocument()
+  })
+
+  it('shows formatted phone number', () => {
+    render(<ContactCard contact={makeContact()} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('+91 98765 43210')).toBeInTheDocument()
+  })
+
+  it('shows relationship labels for all types', () => {
+    render(
+      <ContactCard
+        contact={makeContact({ relationship: 'friend' })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Friend')).toBeInTheDocument()
+  })
+
+  it('renders Edit and Remove buttons', () => {
+    render(<ContactCard contact={makeContact()} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /edit priya sharma/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /remove priya sharma/i })).toBeInTheDocument()
+  })
+
+  it('calls onEdit with contact id when Edit is clicked', async () => {
+    const onEdit = vi.fn()
+    render(<ContactCard contact={makeContact()} onEdit={onEdit} onDelete={vi.fn()} />)
+    await userEvent.click(screen.getByRole('button', { name: /edit priya sharma/i }))
+    expect(onEdit).toHaveBeenCalledWith('ec1')
+  })
+
+  it('calls onDelete with contact id when Remove is clicked', async () => {
+    const onDelete = vi.fn()
+    render(<ContactCard contact={makeContact()} onEdit={vi.fn()} onDelete={onDelete} />)
+    await userEvent.click(screen.getByRole('button', { name: /remove priya sharma/i }))
+    expect(onDelete).toHaveBeenCalledWith('ec1')
+  })
+})

--- a/src/components/emergency/contact-card.tsx
+++ b/src/components/emergency/contact-card.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { Box, Button, Flex, Text } from '@chakra-ui/react'
+import { RELATIONSHIP_LABELS, getInitials, formatPhone } from './emergency-constants'
+import type { EmergencyContact } from '@/types/emergency'
+
+export interface ContactCardProps {
+  contact: EmergencyContact
+  onEdit: (id: string) => void
+  onDelete: (id: string) => void
+}
+
+export function ContactCard({ contact, onEdit, onDelete }: ContactCardProps) {
+  const initials = getInitials(contact.name)
+
+  return (
+    <Box
+      bg="bg.glass"
+      backdropFilter="blur(16px)"
+      borderWidth="1px"
+      borderColor="border.subtle"
+      borderRadius="xl"
+      p="5"
+      boxShadow="glass"
+      transition="transform 0.2s, box-shadow 0.2s"
+      _hover={{ transform: 'translateY(-1px)', boxShadow: 'md' }}
+      data-testid="contact-card"
+    >
+      <Flex align="center" gap="4" flexWrap={{ base: 'wrap', md: 'nowrap' }}>
+        {/* Avatar */}
+        <Flex
+          align="center"
+          justify="center"
+          boxSize="48px"
+          borderRadius="full"
+          flexShrink={0}
+          fontFamily="mono"
+          fontSize="0.95rem"
+          fontWeight="medium"
+          bg="action.primary"
+          color="action.primary.text"
+        >
+          {initials}
+        </Flex>
+
+        {/* Info */}
+        <Box flex="1" minW="0">
+          <Text fontFamily="heading" fontSize="1.05rem" color="text.primary" mb="1">
+            {contact.name}
+          </Text>
+          <Flex align="center" gap="2.5" flexWrap="wrap">
+            <Box
+              as="span"
+              px="2.5"
+              py="0.5"
+              borderRadius="full"
+              bg="bg.overlay"
+              fontSize="0.75rem"
+              fontWeight="medium"
+              color="text.muted"
+            >
+              {RELATIONSHIP_LABELS[contact.relationship]}
+            </Box>
+            <Text fontFamily="mono" fontSize="0.85rem" color="text.secondary">
+              {formatPhone(contact.phone)}
+            </Text>
+          </Flex>
+        </Box>
+
+        {/* Actions */}
+        <Flex
+          gap="2"
+          flexShrink={0}
+          w={{ base: '100%', md: 'auto' }}
+          justify={{ base: 'flex-end', md: 'flex-start' }}
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            borderRadius="full"
+            borderColor="border.default"
+            color="text.secondary"
+            _hover={{ borderColor: 'action.primary', color: 'action.primary' }}
+            onClick={() => onEdit(contact.id)}
+            aria-label={`Edit ${contact.name}`}
+          >
+            Edit
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            borderRadius="full"
+            borderColor="rgba(255, 107, 107, 0.35)"
+            color="coral.400"
+            _hover={{ bg: 'rgba(255, 107, 107, 0.08)', borderColor: 'coral.400' }}
+            onClick={() => onDelete(contact.id)}
+            aria-label={`Remove ${contact.name}`}
+          >
+            Remove
+          </Button>
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/components/emergency/contact-modal.test.tsx
+++ b/src/components/emergency/contact-modal.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, userEvent, waitFor } from '@/test/render'
+import { ContactModal } from './contact-modal'
+import type { EmergencyContact } from '@/types/emergency'
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  onSubmit: vi.fn(),
+  loading: false,
+  initialData: null,
+}
+
+const existingContact: EmergencyContact = {
+  id: 'ec1',
+  name: 'Priya Sharma',
+  phone: '9876543210',
+  relationship: 'spouse',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+}
+
+describe('ContactModal', () => {
+  it('renders "Add Emergency Contact" title when creating', () => {
+    render(<ContactModal {...defaultProps} />)
+    expect(screen.getByText('Add Emergency Contact')).toBeInTheDocument()
+  })
+
+  it('renders "Edit Emergency Contact" title when editing', () => {
+    render(<ContactModal {...defaultProps} initialData={existingContact} />)
+    expect(screen.getByText('Edit Emergency Contact')).toBeInTheDocument()
+  })
+
+  it('shows all form fields', () => {
+    render(<ContactModal {...defaultProps} />)
+    expect(screen.getByText('Full Name')).toBeInTheDocument()
+    expect(screen.getByText('Relationship')).toBeInTheDocument()
+    expect(screen.getByText('Phone Number')).toBeInTheDocument()
+  })
+
+  it('shows +91 prefix', () => {
+    render(<ContactModal {...defaultProps} />)
+    expect(screen.getByText('+91')).toBeInTheDocument()
+  })
+
+  it('pre-fills form fields when editing', async () => {
+    render(<ContactModal {...defaultProps} initialData={existingContact} />)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Enter full name')).toHaveValue('Priya Sharma')
+    })
+    expect(screen.getByPlaceholderText('Enter phone number')).toHaveValue('9876543210')
+  })
+
+  it('shows "Save Contact" button when adding', () => {
+    render(<ContactModal {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Save Contact' })).toBeInTheDocument()
+  })
+
+  it('shows "Save Changes" button when editing', () => {
+    render(<ContactModal {...defaultProps} initialData={existingContact} />)
+    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument()
+  })
+
+  it('shows Cancel button', () => {
+    render(<ContactModal {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+  })
+
+  it('calls onSubmit with form data on valid submission', async () => {
+    const onSubmit = vi.fn()
+    render(<ContactModal {...defaultProps} onSubmit={onSubmit} />)
+
+    await userEvent.type(screen.getByPlaceholderText('Enter full name'), 'Rajesh Kumar')
+    await userEvent.type(screen.getByPlaceholderText('Enter phone number'), '9123456789')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save Contact' }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Rajesh Kumar',
+          phone: '9123456789',
+          relationship: 'spouse',
+        }),
+        expect.anything(),
+      )
+    })
+  })
+
+  it('shows validation error for empty name', async () => {
+    render(<ContactModal {...defaultProps} />)
+
+    await userEvent.type(screen.getByPlaceholderText('Enter phone number'), '9123456789')
+    await userEvent.click(screen.getByRole('button', { name: 'Save Contact' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Required')).toBeInTheDocument()
+    })
+  })
+
+  it('shows validation error for invalid phone', async () => {
+    render(<ContactModal {...defaultProps} />)
+
+    await userEvent.type(screen.getByPlaceholderText('Enter full name'), 'Test User')
+    await userEvent.type(screen.getByPlaceholderText('Enter phone number'), '123')
+    await userEvent.click(screen.getByRole('button', { name: 'Save Contact' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Must be a valid 10-digit Indian mobile number')).toBeInTheDocument()
+    })
+  })
+
+  it('resets form when opened for adding after editing', async () => {
+    const { rerender } = render(
+      <ContactModal {...defaultProps} initialData={existingContact} />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Enter full name')).toHaveValue('Priya Sharma')
+    })
+
+    rerender(
+      <ContactModal {...defaultProps} open={false} initialData={null} />,
+    )
+    rerender(
+      <ContactModal {...defaultProps} open={true} initialData={null} />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Enter full name')).toHaveValue('')
+    })
+  })
+
+  it('shows all relationship options in dropdown', () => {
+    render(<ContactModal {...defaultProps} />)
+    const options = screen.getAllByRole('option')
+    const optionTexts = options.map((opt) => opt.textContent)
+    expect(optionTexts).toContain('Spouse')
+    expect(optionTexts).toContain('Parent')
+    expect(optionTexts).toContain('Sibling')
+    expect(optionTexts).toContain('Child')
+    expect(optionTexts).toContain('Friend')
+    expect(optionTexts).toContain('Other')
+  })
+})

--- a/src/components/emergency/contact-modal.tsx
+++ b/src/components/emergency/contact-modal.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { useEffect } from 'react'
+import {
+  Box,
+  Button,
+  DialogRoot,
+  DialogBackdrop,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+  DialogActionTrigger,
+  DialogPositioner,
+  Field,
+  Flex,
+  Input,
+  NativeSelect,
+  Text,
+} from '@chakra-ui/react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { emergencyContactSchema } from '@/lib/schemas/emergencyContact'
+import { RELATIONSHIP_LABELS } from './emergency-constants'
+import type { EmergencyContact as EmergencyContactFormData } from '@/lib/schemas/emergencyContact'
+import type { EmergencyContact, Relationship } from '@/types/emergency'
+
+export interface ContactModalProps {
+  open: boolean
+  onClose: () => void
+  onSubmit: (data: EmergencyContactFormData) => void
+  loading?: boolean
+  initialData?: EmergencyContact | null
+}
+
+const RELATIONSHIPS = Object.entries(RELATIONSHIP_LABELS) as [Relationship, string][]
+
+export function ContactModal({
+  open,
+  onClose,
+  onSubmit,
+  loading = false,
+  initialData,
+}: ContactModalProps) {
+  const isEdit = !!initialData
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<EmergencyContactFormData>({
+    resolver: zodResolver(emergencyContactSchema),
+    defaultValues: {
+      name: '',
+      phone: '',
+      relationship: 'spouse',
+    },
+  })
+
+  useEffect(() => {
+    if (open) {
+      reset(
+        initialData
+          ? {
+              name: initialData.name,
+              phone: initialData.phone,
+              relationship: initialData.relationship,
+            }
+          : { name: '', phone: '', relationship: 'spouse' },
+      )
+    }
+  }, [open, initialData, reset])
+
+  return (
+    <DialogRoot
+      open={open}
+      onOpenChange={(details) => !details.open && onClose()}
+    >
+      <DialogBackdrop />
+      <DialogPositioner>
+        <DialogContent
+          bg="bg.glass"
+          backdropFilter="blur(24px)"
+          borderColor="border.subtle"
+          borderWidth="1px"
+          boxShadow="glass"
+          borderRadius="2xl"
+          maxW="480px"
+          w="full"
+          mx="4"
+        >
+          <DialogHeader>
+            <DialogTitle fontFamily="heading" fontSize="1.2rem" color="text.primary">
+              {isEdit ? 'Edit Emergency Contact' : 'Add Emergency Contact'}
+            </DialogTitle>
+          </DialogHeader>
+
+          <Box as="form" onSubmit={handleSubmit(onSubmit)}>
+            <DialogBody>
+              <Box
+                height="1px"
+                bg="border.subtle"
+                mb="5"
+              />
+
+              <Box display="flex" flexDirection="column" gap="4">
+                {/* Name */}
+                <Field.Root invalid={!!errors.name}>
+                  <Field.Label color="text.secondary" fontSize="0.82rem" fontWeight="semibold">
+                    Full Name
+                  </Field.Label>
+                  <Input
+                    {...register('name')}
+                    placeholder="Enter full name"
+                    bg="bg.glass"
+                    borderColor="border.default"
+                    borderRadius="xl"
+                    color="text.primary"
+                  />
+                  {errors.name && (
+                    <Field.ErrorText>{errors.name.message}</Field.ErrorText>
+                  )}
+                </Field.Root>
+
+                {/* Relationship */}
+                <Field.Root invalid={!!errors.relationship}>
+                  <Field.Label color="text.secondary" fontSize="0.82rem" fontWeight="semibold">
+                    Relationship
+                  </Field.Label>
+                  <NativeSelect.Root>
+                    <NativeSelect.Field
+                      {...register('relationship')}
+                      bg="bg.glass"
+                      borderColor="border.default"
+                      borderRadius="xl"
+                      color="text.primary"
+                    >
+                      {RELATIONSHIPS.map(([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      ))}
+                    </NativeSelect.Field>
+                    <NativeSelect.Indicator />
+                  </NativeSelect.Root>
+                  {errors.relationship && (
+                    <Field.ErrorText>{errors.relationship.message}</Field.ErrorText>
+                  )}
+                </Field.Root>
+
+                {/* Phone */}
+                <Field.Root invalid={!!errors.phone}>
+                  <Field.Label color="text.secondary" fontSize="0.82rem" fontWeight="semibold">
+                    Phone Number
+                  </Field.Label>
+                  <Flex gap="0">
+                    <Flex
+                      align="center"
+                      px="3"
+                      bg="bg.overlay"
+                      borderWidth="1px"
+                      borderColor="border.default"
+                      borderRight="none"
+                      borderLeftRadius="xl"
+                      fontFamily="mono"
+                      fontSize="0.85rem"
+                      color="text.muted"
+                      fontWeight="medium"
+                    >
+                      <Text>+91</Text>
+                    </Flex>
+                    <Input
+                      {...register('phone')}
+                      type="tel"
+                      placeholder="Enter phone number"
+                      bg="bg.glass"
+                      borderColor="border.default"
+                      borderLeftRadius="0"
+                      borderRightRadius="xl"
+                      color="text.primary"
+                    />
+                  </Flex>
+                  {errors.phone && (
+                    <Field.ErrorText>{errors.phone.message}</Field.ErrorText>
+                  )}
+                </Field.Root>
+              </Box>
+            </DialogBody>
+
+            <DialogFooter>
+              <DialogActionTrigger asChild>
+                <Button variant="ghost" borderRadius="full">
+                  Cancel
+                </Button>
+              </DialogActionTrigger>
+              <Button
+                type="submit"
+                borderRadius="full"
+                bg="action.primary"
+                color="action.primary.text"
+                loading={loading}
+                disabled={loading}
+              >
+                {isEdit ? 'Save Changes' : 'Save Contact'}
+              </Button>
+            </DialogFooter>
+          </Box>
+        </DialogContent>
+      </DialogPositioner>
+    </DialogRoot>
+  )
+}

--- a/src/components/emergency/emergency-constants.test.ts
+++ b/src/components/emergency/emergency-constants.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { MAX_CONTACTS, RELATIONSHIP_LABELS, getInitials, formatPhone } from './emergency-constants'
+
+describe('MAX_CONTACTS', () => {
+  it('is 3', () => {
+    expect(MAX_CONTACTS).toBe(3)
+  })
+})
+
+describe('RELATIONSHIP_LABELS', () => {
+  it('has labels for all relationship types', () => {
+    expect(RELATIONSHIP_LABELS).toEqual({
+      spouse: 'Spouse',
+      parent: 'Parent',
+      sibling: 'Sibling',
+      child: 'Child',
+      friend: 'Friend',
+      other: 'Other',
+    })
+  })
+})
+
+describe('getInitials', () => {
+  it('extracts initials from two-word name', () => {
+    expect(getInitials('Priya Sharma')).toBe('PS')
+  })
+
+  it('extracts initials from three-word name and limits to 2', () => {
+    expect(getInitials('Arun Kumar Mehta')).toBe('AK')
+  })
+
+  it('handles single word', () => {
+    expect(getInitials('Priya')).toBe('P')
+  })
+
+  it('handles empty string', () => {
+    expect(getInitials('')).toBe('')
+  })
+
+  it('uppercases initials', () => {
+    expect(getInitials('priya sharma')).toBe('PS')
+  })
+
+  it('trims extra whitespace', () => {
+    expect(getInitials('  Arun   Kumar  ')).toBe('AK')
+  })
+})
+
+describe('formatPhone', () => {
+  it('formats 10-digit Indian number with +91 prefix', () => {
+    expect(formatPhone('9876543210')).toBe('+91 98765 43210')
+  })
+
+  it('returns non-10-digit numbers as-is', () => {
+    expect(formatPhone('12345')).toBe('12345')
+  })
+
+  it('returns longer numbers as-is', () => {
+    expect(formatPhone('919876543210')).toBe('919876543210')
+  })
+})

--- a/src/components/emergency/emergency-constants.ts
+++ b/src/components/emergency/emergency-constants.ts
@@ -1,0 +1,29 @@
+import type { Relationship } from '@/types/emergency'
+
+export const MAX_CONTACTS = 3
+
+export const RELATIONSHIP_LABELS: Record<Relationship, string> = {
+  spouse: 'Spouse',
+  parent: 'Parent',
+  sibling: 'Sibling',
+  child: 'Child',
+  friend: 'Friend',
+  other: 'Other',
+}
+
+export function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+export function formatPhone(phone: string): string {
+  if (phone.length === 10) {
+    return `+91 ${phone.slice(0, 5)} ${phone.slice(5)}`
+  }
+  return phone
+}

--- a/src/components/emergency/index.ts
+++ b/src/components/emergency/index.ts
@@ -1,0 +1,3 @@
+export { ContactCard } from './contact-card'
+export { ContactModal } from './contact-modal'
+export { MAX_CONTACTS, RELATIONSHIP_LABELS, getInitials, formatPhone } from './emergency-constants'

--- a/src/hooks/emergency/index.ts
+++ b/src/hooks/emergency/index.ts
@@ -1,0 +1,4 @@
+export { useEmergencyContacts } from './use-emergency-contacts'
+export { useCreateEmergencyContact } from './use-create-emergency-contact'
+export { useUpdateEmergencyContact } from './use-update-emergency-contact'
+export { useDeleteEmergencyContact } from './use-delete-emergency-contact'

--- a/src/hooks/emergency/use-create-emergency-contact.test.tsx
+++ b/src/hooks/emergency/use-create-emergency-contact.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { clearEtagCache } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import { useCreateEmergencyContact } from './use-create-emergency-contact'
+import type { EmergencyContactListResponse } from '@/types/emergency'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+let queryClient: QueryClient
+
+function createWrapper(gcTime = 0) {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+const contactRequest = {
+  name: 'Priya Sharma',
+  phone: '9876543210',
+  relationship: 'spouse' as const,
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  clearEtagCache()
+})
+
+describe('useCreateEmergencyContact', () => {
+  it('sends POST request with contact data', async () => {
+    const created = {
+      id: 'ec1',
+      ...contactRequest,
+      createdAt: '2025-01-15T10:00:00Z',
+      updatedAt: '2025-01-15T10:00:00Z',
+    }
+    mockFetch.mockResolvedValue(jsonResponse(created))
+
+    const { result } = renderHook(() => useCreateEmergencyContact(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(() => result.current.mutateAsync(contactRequest))
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(created)
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/v1/emergency-contacts')
+
+    const calledInit = mockFetch.mock.calls[0][1] as RequestInit
+    expect(calledInit.method).toBe('POST')
+    expect(JSON.parse(calledInit.body as string)).toEqual(contactRequest)
+  })
+
+  it('optimistically adds contact to list cache', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: EmergencyContactListResponse = {
+      items: [
+        {
+          id: 'ec-existing',
+          name: 'Rajesh Kumar',
+          phone: '8765432109',
+          relationship: 'parent',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    }
+
+    queryClient.setQueryData(queryKeys.emergencyContacts.list(), initialData)
+
+    let resolveCreate!: () => void
+    mockFetch.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveCreate = () =>
+          resolve(
+            jsonResponse({
+              id: 'ec-new',
+              ...contactRequest,
+              createdAt: '2025-01-15T10:00:00Z',
+              updatedAt: '2025-01-15T10:00:00Z',
+            }),
+          )
+      }),
+    )
+
+    const { result } = renderHook(() => useCreateEmergencyContact(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate(contactRequest)
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<EmergencyContactListResponse>(
+        queryKeys.emergencyContacts.list(),
+      )
+      expect(cached?.items).toHaveLength(2)
+      expect(cached?.items[1].id).toMatch(/^optimistic-/)
+      expect(cached?.items[1].name).toBe('Priya Sharma')
+    })
+
+    await act(async () => {
+      resolveCreate()
+    })
+  })
+
+  it('rolls back cache on error', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: EmergencyContactListResponse = {
+      items: [
+        {
+          id: 'ec-existing',
+          name: 'Rajesh Kumar',
+          phone: '8765432109',
+          relationship: 'parent',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    }
+
+    queryClient.setQueryData(queryKeys.emergencyContacts.list(), initialData)
+
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Bad Request' }, 400))
+
+    const { result } = renderHook(() => useCreateEmergencyContact(), { wrapper })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(contactRequest)
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<EmergencyContactListResponse>(
+        queryKeys.emergencyContacts.list(),
+      )
+      expect(cached?.items).toHaveLength(1)
+      expect(cached?.items[0].id).toBe('ec-existing')
+    })
+  })
+})

--- a/src/hooks/emergency/use-create-emergency-contact.ts
+++ b/src/hooks/emergency/use-create-emergency-contact.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import type {
+  EmergencyContact,
+  EmergencyContactListResponse,
+  CreateEmergencyContactRequest,
+} from '@/types/emergency'
+
+export function useCreateEmergencyContact() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (request: CreateEmergencyContactRequest) =>
+      apiFetch<EmergencyContact>('/v1/emergency-contacts', {
+        method: 'POST',
+        body: request,
+      }),
+    onMutate: async (request) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.emergencyContacts.all })
+
+      const previousLists = queryClient.getQueriesData<EmergencyContactListResponse>(
+        { queryKey: queryKeys.emergencyContacts.all },
+      )
+
+      queryClient.setQueriesData<EmergencyContactListResponse>(
+        { queryKey: queryKeys.emergencyContacts.all },
+        (old) => {
+          if (!old?.items) return old
+          const optimistic: EmergencyContact = {
+            id: `optimistic-${Date.now()}`,
+            name: request.name,
+            phone: request.phone,
+            relationship: request.relationship,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          }
+          return { ...old, items: [...old.items, optimistic] }
+        },
+      )
+
+      return { previousLists }
+    },
+    onError: (_err, _request, context) => {
+      if (context?.previousLists) {
+        for (const [key, data] of context.previousLists) {
+          queryClient.setQueryData(key, data)
+        }
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.emergencyContacts.all })
+    },
+  })
+}

--- a/src/hooks/emergency/use-delete-emergency-contact.test.tsx
+++ b/src/hooks/emergency/use-delete-emergency-contact.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { clearEtagCache } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import { useDeleteEmergencyContact } from './use-delete-emergency-contact'
+import type { EmergencyContactListResponse } from '@/types/emergency'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+let queryClient: QueryClient
+
+function createWrapper(gcTime = 0) {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  clearEtagCache()
+})
+
+describe('useDeleteEmergencyContact', () => {
+  it('sends DELETE request', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(null))
+
+    const { result } = renderHook(() => useDeleteEmergencyContact(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(() => result.current.mutateAsync('ec1'))
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/v1/emergency-contacts/ec1')
+
+    const calledInit = mockFetch.mock.calls[0][1] as RequestInit
+    expect(calledInit.method).toBe('DELETE')
+  })
+
+  it('optimistically removes contact from cache', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: EmergencyContactListResponse = {
+      items: [
+        {
+          id: 'ec1',
+          name: 'Priya Sharma',
+          phone: '9876543210',
+          relationship: 'spouse',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+        {
+          id: 'ec2',
+          name: 'Rajesh Kumar',
+          phone: '8765432109',
+          relationship: 'parent',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    }
+
+    queryClient.setQueryData(queryKeys.emergencyContacts.list(), initialData)
+
+    let resolveDelete!: () => void
+    mockFetch.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveDelete = () => resolve(jsonResponse(null))
+      }),
+    )
+
+    const { result } = renderHook(() => useDeleteEmergencyContact(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate('ec1')
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<EmergencyContactListResponse>(
+        queryKeys.emergencyContacts.list(),
+      )
+      expect(cached?.items).toHaveLength(1)
+      expect(cached?.items[0].id).toBe('ec2')
+    })
+
+    await act(async () => {
+      resolveDelete()
+    })
+  })
+
+  it('rolls back cache on error', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: EmergencyContactListResponse = {
+      items: [
+        {
+          id: 'ec1',
+          name: 'Priya Sharma',
+          phone: '9876543210',
+          relationship: 'spouse',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    }
+
+    queryClient.setQueryData(queryKeys.emergencyContacts.list(), initialData)
+
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Server Error' }, 500))
+
+    const { result } = renderHook(() => useDeleteEmergencyContact(), { wrapper })
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync('ec1')
+      } catch {
+        // expected
+      }
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<EmergencyContactListResponse>(
+        queryKeys.emergencyContacts.list(),
+      )
+      expect(cached?.items).toHaveLength(1)
+      expect(cached?.items[0].id).toBe('ec1')
+    })
+  })
+})

--- a/src/hooks/emergency/use-delete-emergency-contact.ts
+++ b/src/hooks/emergency/use-delete-emergency-contact.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import type { EmergencyContactListResponse } from '@/types/emergency'
+
+export function useDeleteEmergencyContact() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiFetch<void>(`/v1/emergency-contacts/${id}`, { method: 'DELETE' }),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.emergencyContacts.all })
+
+      const previousLists = queryClient.getQueriesData<EmergencyContactListResponse>(
+        { queryKey: queryKeys.emergencyContacts.all },
+      )
+
+      queryClient.setQueriesData<EmergencyContactListResponse>(
+        { queryKey: queryKeys.emergencyContacts.all },
+        (old) => {
+          if (!old?.items) return old
+          return {
+            ...old,
+            items: old.items.filter((c) => c.id !== id),
+          }
+        },
+      )
+
+      return { previousLists }
+    },
+    onError: (_err, _id, context) => {
+      if (context?.previousLists) {
+        for (const [key, data] of context.previousLists) {
+          queryClient.setQueryData(key, data)
+        }
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.emergencyContacts.all })
+    },
+  })
+}

--- a/src/hooks/emergency/use-emergency-contacts.test.tsx
+++ b/src/hooks/emergency/use-emergency-contacts.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { clearEtagCache } from '@/lib/api/client'
+import { useEmergencyContacts } from './use-emergency-contacts'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  clearEtagCache()
+})
+
+describe('useEmergencyContacts', () => {
+  it('fetches emergency contacts successfully', async () => {
+    const data = {
+      items: [
+        {
+          id: 'ec1',
+          name: 'Priya Sharma',
+          phone: '9876543210',
+          relationship: 'spouse',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    }
+    mockFetch.mockResolvedValue(jsonResponse(data))
+
+    const { result } = renderHook(() => useEmergencyContacts(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(data)
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/v1/emergency-contacts')
+  })
+
+  it('returns error state on failure', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: 'Internal server error' }, 500),
+    )
+
+    const { result } = renderHook(() => useEmergencyContacts(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toMatchObject({ status: 500 })
+  })
+})

--- a/src/hooks/emergency/use-emergency-contacts.ts
+++ b/src/hooks/emergency/use-emergency-contacts.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import { staleTimes } from '@/lib/api/stale-times'
+import type { EmergencyContactListResponse } from '@/types/emergency'
+
+export function useEmergencyContacts() {
+  return useQuery({
+    queryKey: queryKeys.emergencyContacts.list(),
+    queryFn: () => apiFetch<EmergencyContactListResponse>('/v1/emergency-contacts'),
+    staleTime: staleTimes.emergencyContacts,
+  })
+}

--- a/src/hooks/emergency/use-update-emergency-contact.test.tsx
+++ b/src/hooks/emergency/use-update-emergency-contact.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { clearEtagCache } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import { useUpdateEmergencyContact } from './use-update-emergency-contact'
+import type { EmergencyContactListResponse } from '@/types/emergency'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+let queryClient: QueryClient
+
+function createWrapper(gcTime = 0) {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime },
+      mutations: { retry: false },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  clearEtagCache()
+})
+
+describe('useUpdateEmergencyContact', () => {
+  it('sends PUT request with updated contact data', async () => {
+    const updated = {
+      id: 'ec1',
+      name: 'Priya S.',
+      phone: '9876543210',
+      relationship: 'spouse',
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-15T10:00:00Z',
+    }
+    mockFetch.mockResolvedValue(jsonResponse(updated))
+
+    const { result } = renderHook(() => useUpdateEmergencyContact(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(() =>
+      result.current.mutateAsync({
+        id: 'ec1',
+        name: 'Priya S.',
+        phone: '9876543210',
+        relationship: 'spouse',
+      }),
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/v1/emergency-contacts/ec1')
+
+    const calledInit = mockFetch.mock.calls[0][1] as RequestInit
+    expect(calledInit.method).toBe('PUT')
+  })
+
+  it('optimistically updates contact in cache', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: EmergencyContactListResponse = {
+      items: [
+        {
+          id: 'ec1',
+          name: 'Priya Sharma',
+          phone: '9876543210',
+          relationship: 'spouse',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    }
+
+    queryClient.setQueryData(queryKeys.emergencyContacts.list(), initialData)
+
+    let resolveUpdate!: () => void
+    mockFetch.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveUpdate = () =>
+          resolve(
+            jsonResponse({
+              id: 'ec1',
+              name: 'Priya S.',
+              phone: '9876543210',
+              relationship: 'spouse',
+              createdAt: '2025-01-01T00:00:00Z',
+              updatedAt: '2025-01-15T10:00:00Z',
+            }),
+          )
+      }),
+    )
+
+    const { result } = renderHook(() => useUpdateEmergencyContact(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate({
+        id: 'ec1',
+        name: 'Priya S.',
+        phone: '9876543210',
+        relationship: 'spouse',
+      })
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<EmergencyContactListResponse>(
+        queryKeys.emergencyContacts.list(),
+      )
+      expect(cached?.items[0].name).toBe('Priya S.')
+    })
+
+    await act(async () => {
+      resolveUpdate()
+    })
+  })
+})

--- a/src/hooks/emergency/use-update-emergency-contact.ts
+++ b/src/hooks/emergency/use-update-emergency-contact.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api/client'
+import { queryKeys } from '@/lib/api/query-keys'
+import type {
+  EmergencyContact,
+  EmergencyContactListResponse,
+  UpdateEmergencyContactRequest,
+} from '@/types/emergency'
+
+export function useUpdateEmergencyContact() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, ...request }: UpdateEmergencyContactRequest & { id: string }) =>
+      apiFetch<EmergencyContact>(`/v1/emergency-contacts/${id}`, {
+        method: 'PUT',
+        body: request,
+      }),
+    onMutate: async ({ id, ...request }) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.emergencyContacts.all })
+
+      const previousLists = queryClient.getQueriesData<EmergencyContactListResponse>(
+        { queryKey: queryKeys.emergencyContacts.all },
+      )
+
+      queryClient.setQueriesData<EmergencyContactListResponse>(
+        { queryKey: queryKeys.emergencyContacts.all },
+        (old) => {
+          if (!old?.items) return old
+          return {
+            ...old,
+            items: old.items.map((c) =>
+              c.id === id
+                ? { ...c, ...request, updatedAt: new Date().toISOString() }
+                : c,
+            ),
+          }
+        },
+      )
+
+      return { previousLists }
+    },
+    onError: (_err, _request, context) => {
+      if (context?.previousLists) {
+        for (const [key, data] of context.previousLists) {
+          queryClient.setQueryData(key, data)
+        }
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.emergencyContacts.all })
+    },
+  })
+}

--- a/src/lib/api/query-keys.test.ts
+++ b/src/lib/api/query-keys.test.ts
@@ -64,4 +64,18 @@ describe('queryKeys', () => {
       expect(queryKeys.consents.detail('y')).toEqual(['consents', 'detail', 'y'])
     })
   })
+
+  describe('emergencyContacts', () => {
+    it('has correct base key', () => {
+      expect(queryKeys.emergencyContacts.all).toEqual(['emergencyContacts'])
+    })
+
+    it('produces list key', () => {
+      expect(queryKeys.emergencyContacts.list()).toEqual(['emergencyContacts', 'list'])
+    })
+
+    it('produces detail key', () => {
+      expect(queryKeys.emergencyContacts.detail('z')).toEqual(['emergencyContacts', 'detail', 'z'])
+    })
+  })
 })

--- a/src/lib/api/query-keys.ts
+++ b/src/lib/api/query-keys.ts
@@ -29,4 +29,10 @@ export const queryKeys = {
     detail: (id: string) =>
       [...queryKeys.consents.all, 'detail', id] as const,
   },
+  emergencyContacts: {
+    all: ['emergencyContacts'] as const,
+    list: () => [...queryKeys.emergencyContacts.all, 'list'] as const,
+    detail: (id: string) =>
+      [...queryKeys.emergencyContacts.all, 'detail', id] as const,
+  },
 }

--- a/src/lib/api/stale-times.test.ts
+++ b/src/lib/api/stale-times.test.ts
@@ -17,4 +17,8 @@ describe('staleTimes', () => {
   it('consents stale time is 30 seconds', () => {
     expect(staleTimes.consents).toBe(30_000)
   })
+
+  it('emergencyContacts stale time is 1 minute', () => {
+    expect(staleTimes.emergencyContacts).toBe(60_000)
+  })
 })

--- a/src/lib/api/stale-times.ts
+++ b/src/lib/api/stale-times.ts
@@ -3,4 +3,5 @@ export const staleTimes = {
   profile: 10 * 60 * 1000, // 10 min
   accessGrants: 1 * 60 * 1000, // 1 min
   consents: 30 * 1000, // 30 sec
+  emergencyContacts: 1 * 60 * 1000, // 1 min
 }

--- a/src/types/emergency.ts
+++ b/src/types/emergency.ts
@@ -1,0 +1,26 @@
+export type Relationship = 'spouse' | 'parent' | 'sibling' | 'child' | 'friend' | 'other'
+
+export interface EmergencyContact {
+  id: string
+  name: string
+  phone: string
+  relationship: Relationship
+  createdAt: string
+  updatedAt: string
+}
+
+export interface EmergencyContactListResponse {
+  items: EmergencyContact[]
+}
+
+export interface CreateEmergencyContactRequest {
+  name: string
+  phone: string
+  relationship: Relationship
+}
+
+export interface UpdateEmergencyContactRequest {
+  name: string
+  phone: string
+  relationship: Relationship
+}


### PR DESCRIPTION
## Summary
- Add emergency contacts page at `(portal)/emergency/` with full CRUD operations
- Implement 4 TanStack Query hooks with optimistic updates and rollback (`useEmergencyContacts`, `useCreateEmergencyContact`, `useUpdateEmergencyContact`, `useDeleteEmergencyContact`)
- Build glass-morphic contact cards, add/edit modal with React Hook Form + Zod validation, delete confirmation dialog
- Support max 3 contacts limit with disabled state and tooltip
- Add query keys and stale times for emergency contacts (1 min)
- 57 new tests across 8 test files (634 total pass)

Closes #22

## Test plan
- [ ] Verify loading skeleton appears while data loads
- [ ] Verify empty state shows when no contacts exist
- [ ] Add a new contact via modal and verify it appears
- [ ] Edit an existing contact and verify changes persist
- [ ] Delete a contact via confirmation dialog
- [ ] Verify "Add Contact" is disabled at 3-contact limit
- [ ] Verify form validation (empty name, invalid phone number)
- [ ] Test optimistic updates (contact appears immediately before server responds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)