### PR TITLE
Add Kubernetes deployment pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.next/
+node_modules/
+.git/
+docs/
+coverage/
+test-results/
+playwright-report/
+.env.local
+.env*.local
+*.md
+.github/
+k8s/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,179 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: cd-deploy-frontend
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      IMAGE_TAG: ${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/kinveetech/aarogyafrontend:latest
+            ghcr.io/kinveetech/aarogyafrontend:${{ env.IMAGE_TAG }}
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Deploy to k3s
+        uses: appleboy/ssh-action@v1
+        with:
+          host: 100.108.60.90
+          username: sk
+          key: ${{ secrets.DEV_SSH_KEY }}
+          envs: IMAGE_TAG
+          script: |
+            mkdir -p ~/k8s-frontend
+            cat > ~/k8s-frontend/namespace.yaml << 'NSEOF'
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: aarogya-frontend
+            NSEOF
+
+            cat > ~/k8s-frontend/app.yaml << 'APPEOF'
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: frontend-secret
+              namespace: aarogya-frontend
+            type: Opaque
+            stringData:
+              AUTH_SECRET: "CHANGE_ME"
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              name: aarogya-frontend
+              namespace: aarogya-frontend
+              labels:
+                app: aarogya-frontend
+            spec:
+              replicas: 1
+              selector:
+                matchLabels:
+                  app: aarogya-frontend
+              template:
+                metadata:
+                  labels:
+                    app: aarogya-frontend
+                spec:
+                  imagePullSecrets:
+                    - name: ghcr-secret
+                  containers:
+                    - name: aarogya-frontend
+                      image: ghcr.io/kinveetech/aarogyafrontend:latest
+                      imagePullPolicy: Always
+                      ports:
+                        - containerPort: 3000
+                      env:
+                        - name: AUTH_SECRET
+                          valueFrom:
+                            secretKeyRef:
+                              name: frontend-secret
+                              key: AUTH_SECRET
+                        - name: AUTH_URL
+                          value: "http://dev.kinvee.in:30000"
+                        - name: API_URL
+                          value: "http://aarogya-api.aarogya.svc.cluster.local"
+                        - name: COGNITO_DOMAIN
+                          value: ""
+                        - name: COGNITO_ISSUER
+                          value: ""
+                        - name: COGNITO_CLIENT_ID
+                          value: ""
+                        - name: COGNITO_CLIENT_SECRET
+                          value: ""
+                        - name: NEXT_PUBLIC_FIREBASE_API_KEY
+                          value: ""
+                        - name: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+                          value: ""
+                        - name: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+                          value: ""
+                        - name: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+                          value: ""
+                        - name: NEXT_PUBLIC_FIREBASE_APP_ID
+                          value: ""
+                        - name: NEXT_PUBLIC_FIREBASE_VAPID_KEY
+                          value: ""
+                      livenessProbe:
+                        httpGet:
+                          path: /api/health
+                          port: 3000
+                        initialDelaySeconds: 15
+                        periodSeconds: 20
+                      readinessProbe:
+                        httpGet:
+                          path: /api/health
+                          port: 3000
+                        initialDelaySeconds: 10
+                        periodSeconds: 10
+                      resources:
+                        requests:
+                          memory: "128Mi"
+                          cpu: "100m"
+                        limits:
+                          memory: "512Mi"
+                          cpu: "500m"
+            ---
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: aarogya-frontend
+              namespace: aarogya-frontend
+              labels:
+                app: aarogya-frontend
+            spec:
+              type: NodePort
+              selector:
+                app: aarogya-frontend
+              ports:
+                - port: 80
+                  targetPort: 3000
+                  nodePort: 30000
+            APPEOF
+
+            cat > ~/k8s-frontend/kustomization.yaml << 'KEOF'
+            apiVersion: kustomize.config.k8s.io/v1beta1
+            kind: Kustomization
+            resources:
+              - namespace.yaml
+              - app.yaml
+            KEOF
+
+            kubectl apply -k ~/k8s-frontend/
+            kubectl -n aarogya-frontend set image deployment/aarogya-frontend aarogya-frontend=ghcr.io/kinveetech/aarogyafrontend:${IMAGE_TAG}
+            kubectl -n aarogya-frontend rollout status deployment/aarogya-frontend --timeout=120s

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Stage 1: Install dependencies
+FROM node:24-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+# Stage 2: Build the application
+FROM node:24-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG AUTH_SECRET=build-placeholder
+ARG COGNITO_DOMAIN=https://placeholder.auth.region.amazoncognito.com
+ARG COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_placeholder
+ARG COGNITO_CLIENT_ID=placeholder
+ARG COGNITO_CLIENT_SECRET=placeholder
+ARG API_URL=http://localhost:5000
+
+ENV AUTH_SECRET=$AUTH_SECRET \
+    COGNITO_DOMAIN=$COGNITO_DOMAIN \
+    COGNITO_ISSUER=$COGNITO_ISSUER \
+    COGNITO_CLIENT_ID=$COGNITO_CLIENT_ID \
+    COGNITO_CLIENT_SECRET=$COGNITO_CLIENT_SECRET \
+    API_URL=$API_URL
+
+RUN npm run build
+
+# Stage 3: Production runner
+FROM node:24-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=build /app/public ./public
+COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: frontend-secret
+  namespace: aarogya-frontend
+type: Opaque
+stringData:
+  AUTH_SECRET: "CHANGE_ME"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aarogya-frontend
+  namespace: aarogya-frontend
+  labels:
+    app: aarogya-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aarogya-frontend
+  template:
+    metadata:
+      labels:
+        app: aarogya-frontend
+    spec:
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: aarogya-frontend
+          image: ghcr.io/kinveetech/aarogyafrontend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+          env:
+            - name: AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: frontend-secret
+                  key: AUTH_SECRET
+            - name: AUTH_URL
+              value: "http://dev.kinvee.in:30000"
+            - name: API_URL
+              value: "http://aarogya-api.aarogya.svc.cluster.local"
+            - name: COGNITO_DOMAIN
+              value: ""
+            - name: COGNITO_ISSUER
+              value: ""
+            - name: COGNITO_CLIENT_ID
+              value: ""
+            - name: COGNITO_CLIENT_SECRET
+              value: ""
+            - name: NEXT_PUBLIC_FIREBASE_API_KEY
+              value: ""
+            - name: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+              value: ""
+            - name: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+              value: ""
+            - name: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+              value: ""
+            - name: NEXT_PUBLIC_FIREBASE_APP_ID
+              value: ""
+            - name: NEXT_PUBLIC_FIREBASE_VAPID_KEY
+              value: ""
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aarogya-frontend
+  namespace: aarogya-frontend
+  labels:
+    app: aarogya-frontend
+spec:
+  type: NodePort
+  selector:
+    app: aarogya-frontend
+  ports:
+    - port: 80
+      targetPort: 3000
+      nodePort: 30000

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - app.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aarogya-frontend

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,7 @@ const withSerwist = withSerwistInit({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   // pdfjs-dist optionally depends on canvas (node-only); alias to false for the browser bundle
   turbopack: {
     resolveAlias: {

--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { GET } from './route'
+
+describe('GET /api/health', () => {
+  it('returns 200 with status ok', async () => {
+    const response = GET()
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body).toEqual({ status: 'ok' })
+  })
+})

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ status: 'ok' })
+}


### PR DESCRIPTION
## Summary
- Add `output: 'standalone'` to Next.js config for optimised Docker image (~100MB vs ~1GB)
- Create `GET /api/health` endpoint for K8s liveness/readiness probes (with unit test)
- Add multi-stage Dockerfile (node:24-alpine, non-root user, 3-stage build)
- Add K8s manifests in `k8s/`: namespace (`aarogya-frontend`), deployment, secret, NodePort service (port 30000)
- Add CD workflow triggered on CI success: build & push to GHCR → Tailscale → SSH deploy to k3s dev server
- Frontend reaches backend via K8s internal DNS (`http://aarogya-api.aarogya.svc.cluster.local`)

## Test plan
- [ ] Health route unit test passes (`vitest run src/app/api/health/route.test.ts`)
- [ ] Build succeeds with `output: 'standalone'` (`.next/standalone/server.js` generated)
- [ ] `docker build -t aarogya-frontend .` completes successfully
- [ ] `docker run -p 3000:3000 aarogya-frontend` → `curl localhost:3000/api/health` returns `{"status":"ok"}`
- [ ] Push to main → CI passes → CD triggers → image pushed to GHCR → deployed to k3s
- [ ] `curl http://<dev-server>:30000/api/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)