### PR TITLE
Fix CD deploy: use ssh/scp pattern matching backend

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,15 +13,12 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.event.workflow_run.conclusion == 'success'
+    timeout-minutes: 15
 
     permissions:
       contents: read
       packages: write
-
-    env:
-      IMAGE_TAG: ${{ github.sha }}
-      AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
 
     steps:
       - uses: actions/checkout@v6
@@ -40,7 +37,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/kinveetech/aarogyafrontend:latest
-            ghcr.io/kinveetech/aarogyafrontend:${{ env.IMAGE_TAG }}
+            ghcr.io/kinveetech/aarogyafrontend:${{ github.event.workflow_run.head_sha }}
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@v3
@@ -50,132 +47,25 @@ jobs:
           tags: tag:ci
 
       - name: Deploy to k3s
-        uses: appleboy/ssh-action@v1
-        with:
-          host: 100.108.60.90
-          username: sk
-          key: ${{ secrets.DEV_SSH_KEY }}
-          envs: IMAGE_TAG,AUTH_SECRET
-          script: |
-            mkdir -p ~/k8s-frontend
-            cat > ~/k8s-frontend/namespace.yaml << 'NSEOF'
-            apiVersion: v1
-            kind: Namespace
-            metadata:
-              name: aarogya-frontend
-            NSEOF
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.DEV_SSH_KEY }}
+          IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
 
-            cat > ~/k8s-frontend/app.yaml << 'APPEOF'
-            apiVersion: v1
-            kind: Secret
-            metadata:
-              name: frontend-secret
-              namespace: aarogya-frontend
-            type: Opaque
-            stringData:
-              AUTH_SECRET: "PLACEHOLDER_REPLACED_BY_CD"
-            ---
-            apiVersion: apps/v1
-            kind: Deployment
-            metadata:
-              name: aarogya-frontend
-              namespace: aarogya-frontend
-              labels:
-                app: aarogya-frontend
-            spec:
-              replicas: 1
-              selector:
-                matchLabels:
-                  app: aarogya-frontend
-              template:
-                metadata:
-                  labels:
-                    app: aarogya-frontend
-                spec:
-                  imagePullSecrets:
-                    - name: ghcr-secret
-                  containers:
-                    - name: aarogya-frontend
-                      image: ghcr.io/kinveetech/aarogyafrontend:latest
-                      imagePullPolicy: Always
-                      ports:
-                        - containerPort: 3000
-                      env:
-                        - name: AUTH_SECRET
-                          valueFrom:
-                            secretKeyRef:
-                              name: frontend-secret
-                              key: AUTH_SECRET
-                        - name: AUTH_URL
-                          value: "http://dev.kinvee.in:30000"
-                        - name: API_URL
-                          value: "http://aarogya-api.aarogya.svc.cluster.local"
-                        - name: COGNITO_DOMAIN
-                          value: ""
-                        - name: COGNITO_ISSUER
-                          value: ""
-                        - name: COGNITO_CLIENT_ID
-                          value: ""
-                        - name: COGNITO_CLIENT_SECRET
-                          value: ""
-                        - name: NEXT_PUBLIC_FIREBASE_API_KEY
-                          value: ""
-                        - name: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
-                          value: ""
-                        - name: NEXT_PUBLIC_FIREBASE_PROJECT_ID
-                          value: ""
-                        - name: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
-                          value: ""
-                        - name: NEXT_PUBLIC_FIREBASE_APP_ID
-                          value: ""
-                        - name: NEXT_PUBLIC_FIREBASE_VAPID_KEY
-                          value: ""
-                      livenessProbe:
-                        httpGet:
-                          path: /api/health
-                          port: 3000
-                        initialDelaySeconds: 15
-                        periodSeconds: 20
-                      readinessProbe:
-                        httpGet:
-                          path: /api/health
-                          port: 3000
-                        initialDelaySeconds: 10
-                        periodSeconds: 10
-                      resources:
-                        requests:
-                          memory: "128Mi"
-                          cpu: "100m"
-                        limits:
-                          memory: "512Mi"
-                          cpu: "500m"
-            ---
-            apiVersion: v1
-            kind: Service
-            metadata:
-              name: aarogya-frontend
-              namespace: aarogya-frontend
-              labels:
-                app: aarogya-frontend
-            spec:
-              type: NodePort
-              selector:
-                app: aarogya-frontend
-              ports:
-                - port: 80
-                  targetPort: 3000
-                  nodePort: 30000
-            APPEOF
+          # Inject AUTH_SECRET into manifest before copying
+          sed -i "s|PLACEHOLDER_REPLACED_BY_CD|${AUTH_SECRET}|g" k8s/app.yaml
 
-            cat > ~/k8s-frontend/kustomization.yaml << 'KEOF'
-            apiVersion: kustomize.config.k8s.io/v1beta1
-            kind: Kustomization
-            resources:
-              - namespace.yaml
-              - app.yaml
-            KEOF
+          ssh -o StrictHostKeyChecking=no sk@100.108.60.90 "mkdir -p ~/k8s-frontend"
+          scp -o StrictHostKeyChecking=no k8s/*.yaml sk@100.108.60.90:~/k8s-frontend/
 
-            sed -i "s|PLACEHOLDER_REPLACED_BY_CD|${AUTH_SECRET}|g" ~/k8s-frontend/app.yaml
-            sudo kubectl apply -k ~/k8s-frontend/
-            sudo kubectl -n aarogya-frontend set image deployment/aarogya-frontend aarogya-frontend=ghcr.io/kinveetech/aarogyafrontend:${IMAGE_TAG}
-            sudo kubectl -n aarogya-frontend rollout status deployment/aarogya-frontend --timeout=120s
+          ssh -o StrictHostKeyChecking=no sk@100.108.60.90 << EOF
+            export KUBECONFIG=/home/sk/.kube/config
+            kubectl apply -k ~/k8s-frontend/
+            kubectl -n aarogya-frontend set image deployment/aarogya-frontend \
+              aarogya-frontend=ghcr.io/kinveetech/aarogyafrontend:${IMAGE_TAG}
+            kubectl -n aarogya-frontend rollout status deployment/aarogya-frontend --timeout=120s
+          EOF


### PR DESCRIPTION
## Summary
- Replace `appleboy/ssh-action` with raw `ssh`/`scp` + `KUBECONFIG` env var, matching the backend repo's deploy pattern
- Fixes `sudo: a password is required` error — the `sk` user has a user-readable kubeconfig at `/home/sk/.kube/config`
- Copy manifests via `scp` instead of inline heredocs, keeping the workflow cleaner
- Use `github.event.workflow_run.head_sha` for consistent image tagging (matches backend)

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, CD triggers → image builds → Tailscale connects → SSH deploys successfully
- [ ] `kubectl -n aarogya-frontend get pods` shows running pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)