### PR TITLE
Set Cognito placeholder values in K8s manifest

### DIFF
--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -43,13 +43,13 @@ spec:
             - name: API_URL
               value: "http://aarogya-api.aarogya.svc.cluster.local"
             - name: COGNITO_DOMAIN
-              value: ""
+              value: "https://auth.dev-placeholder.example.com"
             - name: COGNITO_ISSUER
-              value: ""
+              value: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_placeholder"
             - name: COGNITO_CLIENT_ID
-              value: ""
+              value: "dev-placeholder-client-id"
             - name: COGNITO_CLIENT_SECRET
-              value: ""
+              value: "dev-placeholder-client-secret"
             - name: NEXT_PUBLIC_FIREBASE_API_KEY
               value: ""
             - name: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN


### PR DESCRIPTION
## Summary
- Replace empty Cognito env vars with CI-style placeholder values in K8s manifest
- Fixes runtime crash: `requireEnv()` throws on empty strings, crashing the auth middleware
- Auth won't function until real Cognito is configured, but the app will load

## Test plan
- [ ] CI passes
- [ ] After merge + deploy, `curl http://dev.kinvee.in:30000/api/health` returns 200
- [ ] App loads without `Missing required environment variable: COGNITO_DOMAIN` errors in pod logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)