### PR TITLE
Add Apple Sign In button to login page

### DIFF
--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -63,10 +63,11 @@ describe('LoginPage', () => {
     mockSignIn.mockReset()
   })
 
-  it('renders three auth buttons', () => {
+  it('renders four auth buttons', () => {
     render(<LoginPage />)
     expect(screen.getByRole('button', { name: /continue with phone/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /continue with google/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /continue with apple/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /continue with email/i })).toBeInTheDocument()
   })
 
@@ -119,6 +120,14 @@ describe('LoginPage', () => {
     render(<LoginPage />)
 
     await user.click(screen.getByRole('button', { name: /continue with google/i }))
+    expect(mockSignIn).toHaveBeenCalledWith('cognito-pkce', { callbackUrl: '/reports' })
+  })
+
+  it('calls signIn with cognito-pkce when apple button clicked', async () => {
+    const user = userEvent.setup()
+    render(<LoginPage />)
+
+    await user.click(screen.getByRole('button', { name: /continue with apple/i }))
     expect(mockSignIn).toHaveBeenCalledWith('cognito-pkce', { callbackUrl: '/reports' })
   })
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -35,6 +35,14 @@ function GoogleIcon() {
   )
 }
 
+function AppleIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+    </svg>
+  )
+}
+
 function EmailIcon() {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -142,6 +150,24 @@ function LoginCard() {
             >
               <Box as="span" mr={2} display="inline-flex"><GoogleIcon /></Box>
               Continue with Google
+            </Button>
+
+            <Button
+              w="full"
+              h="48px"
+              borderRadius="full"
+              bg="transparent"
+              border="1px solid"
+              borderColor="border.default"
+              color="text.primary"
+              _hover={{ bg: 'bg.overlay', transform: 'translateY(-1px)' }}
+              transition="all 0.2s ease"
+              onClick={handleSignIn}
+              fontSize="sm"
+              fontWeight="medium"
+            >
+              <Box as="span" mr={2} display="inline-flex"><AppleIcon /></Box>
+              Continue with Apple
             </Button>
 
             <Button


### PR DESCRIPTION
## Summary
- Adds "Continue with Apple" button to the login page between Google and Email
- Uses the same `cognito-pkce` sign-in flow (actual Apple IdP is configured in Cognito separately)
- Apple logo SVG uses `currentColor` fill for light/dark theme support
- Includes test coverage for rendering and click behavior

## Test plan
- [x] `npx vitest run src/app/(auth)/login/page.test.tsx` — all 15 tests pass
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — no type errors
- [ ] Visual check: button appears between Google and Email with correct styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)