### PR TITLE
feat(auth): wire Cognito OIDC flow for real token exchange

### DIFF
--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -6,6 +6,8 @@ metadata:
 type: Opaque
 stringData:
   AUTH_SECRET: "PLACEHOLDER_REPLACED_BY_CD"
+  COGNITO_CLIENT_ID: "REPLACE_WITH_WEB_CLIENT_ID"
+  COGNITO_CLIENT_SECRET: "REPLACE_WITH_WEB_CLIENT_SECRET"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -43,13 +45,19 @@ spec:
             - name: API_URL
               value: "http://aarogya-api.aarogya.svc.cluster.local"
             - name: COGNITO_DOMAIN
-              value: "https://auth.dev-placeholder.example.com"
+              value: "https://aarogya-dev.auth.ap-south-1.amazoncognito.com"
             - name: COGNITO_ISSUER
-              value: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_placeholder"
+              value: "https://cognito-idp.ap-south-1.amazonaws.com/ap-south-1_I827gkdF7"
             - name: COGNITO_CLIENT_ID
-              value: "dev-placeholder-client-id"
+              valueFrom:
+                secretKeyRef:
+                  name: frontend-secret
+                  key: COGNITO_CLIENT_ID
             - name: COGNITO_CLIENT_SECRET
-              value: "dev-placeholder-client-secret"
+              valueFrom:
+                secretKeyRef:
+                  name: frontend-secret
+                  key: COGNITO_CLIENT_SECRET
             - name: NEXT_PUBLIC_FIREBASE_API_KEY
               value: ""
             - name: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN

--- a/src/lib/auth/cognito-provider.test.ts
+++ b/src/lib/auth/cognito-provider.test.ts
@@ -27,10 +27,10 @@ describe('CognitoPKCE provider', () => {
     })
   })
 
-  it('uses backend token endpoint', () => {
+  it('uses Cognito token endpoint', () => {
     const provider = CognitoPKCE()
     expect(provider.token).toEqual({
-      url: 'https://api.example.com/auth/pkce/token',
+      url: 'https://auth.example.com/oauth2/token',
     })
   })
 

--- a/src/lib/auth/cognito-provider.ts
+++ b/src/lib/auth/cognito-provider.ts
@@ -18,7 +18,6 @@ function requireEnv(name: string): string {
 
 export default function CognitoPKCE(): OIDCConfig<CognitoProfile> {
   const cognitoDomain = requireEnv('COGNITO_DOMAIN')
-  const apiUrl = requireEnv('API_URL')
 
   return {
     id: 'cognito-pkce',
@@ -32,7 +31,7 @@ export default function CognitoPKCE(): OIDCConfig<CognitoProfile> {
       params: { scope: 'openid email profile' },
     },
     token: {
-      url: `${apiUrl}/auth/pkce/token`,
+      url: `${cognitoDomain}/oauth2/token`,
     },
     userinfo: {
       url: `${cognitoDomain}/oauth2/userInfo`,

--- a/src/lib/auth/refresh-token.test.ts
+++ b/src/lib/auth/refresh-token.test.ts
@@ -22,9 +22,9 @@ describe('refreshAccessToken', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          access_token: 'new-access',
-          refresh_token: 'new-refresh',
-          expires_in: 3600,
+          accessToken: 'new-access',
+          refreshToken: 'new-refresh',
+          expiresInSeconds: 3600,
         }),
         { status: 200 },
       ),
@@ -32,11 +32,14 @@ describe('refreshAccessToken', () => {
 
     const result = await refreshAccessToken(baseToken)
 
-    expect(fetch).toHaveBeenCalledWith('https://api.example.com/auth/token/refresh', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refresh_token: 'old-refresh' }),
-    })
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.example.com/api/auth/social/token/refresh',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken: 'old-refresh' }),
+      },
+    )
 
     expect(result.accessToken).toBe('new-access')
     expect(result.refreshToken).toBe('new-refresh')
@@ -48,9 +51,9 @@ describe('refreshAccessToken', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          access_token: 'rotated-access',
-          refresh_token: 'rotated-refresh',
-          expires_in: 1800,
+          accessToken: 'rotated-access',
+          refreshToken: 'rotated-refresh',
+          expiresInSeconds: 1800,
         }),
         { status: 200 },
       ),

--- a/src/lib/auth/refresh-token.ts
+++ b/src/lib/auth/refresh-token.ts
@@ -1,9 +1,9 @@
 import type { JWT } from 'next-auth/jwt'
 
 interface RefreshResponse {
-  access_token: string
-  refresh_token: string
-  expires_in: number
+  accessToken: string
+  refreshToken: string
+  expiresInSeconds: number
 }
 
 export async function refreshAccessToken(token: JWT): Promise<JWT> {
@@ -12,10 +12,10 @@ export async function refreshAccessToken(token: JWT): Promise<JWT> {
     throw new Error('Missing required environment variable: API_URL')
   }
 
-  const response = await fetch(`${apiUrl}/auth/token/refresh`, {
+  const response = await fetch(`${apiUrl}/api/auth/social/token/refresh`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ refresh_token: token.refreshToken }),
+    body: JSON.stringify({ refreshToken: token.refreshToken }),
   })
 
   if (!response.ok) {
@@ -26,9 +26,9 @@ export async function refreshAccessToken(token: JWT): Promise<JWT> {
 
   return {
     ...token,
-    accessToken: data.access_token,
-    refreshToken: data.refresh_token,
-    expiresAt: Math.floor(Date.now() / 1000) + data.expires_in,
+    accessToken: data.accessToken,
+    refreshToken: data.refreshToken,
+    expiresAt: Math.floor(Date.now() / 1000) + data.expiresInSeconds,
     error: undefined,
   }
 }

--- a/src/lib/auth/revoke-token.test.ts
+++ b/src/lib/auth/revoke-token.test.ts
@@ -16,18 +16,18 @@ afterEach(() => {
 })
 
 describe('revokeToken', () => {
-  it('calls POST /auth/token/revoke with refresh token', async () => {
+  it('calls POST /api/auth/social/token/revoke with refresh token', async () => {
     mockFetch.mockResolvedValue(new Response(null, { status: 200 }))
 
     const { revokeToken } = await import('./revoke-token')
     await revokeToken('rt-abc-123')
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.example.com/auth/token/revoke',
+      'https://api.example.com/api/auth/social/token/revoke',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refresh_token: 'rt-abc-123' }),
+        body: JSON.stringify({ refreshToken: 'rt-abc-123' }),
       },
     )
   })

--- a/src/lib/auth/revoke-token.ts
+++ b/src/lib/auth/revoke-token.ts
@@ -5,10 +5,10 @@ export async function revokeToken(refreshToken: string): Promise<void> {
   }
 
   try {
-    const response = await fetch(`${apiUrl}/auth/token/revoke`, {
+    const response = await fetch(`${apiUrl}/api/auth/social/token/revoke`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refresh_token: refreshToken }),
+      body: JSON.stringify({ refreshToken }),
     })
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- Token exchange: point to Cognito `/oauth2/token` instead of backend mock PKCE endpoint
- Token refresh: use backend `/api/auth/social/token/refresh` (proxies to Cognito), matching `SocialRefreshTokenCommand` contract (camelCase `refreshToken`)
- Token revoke: use backend `/api/auth/social/token/revoke` matching `SocialRevokeTokenCommand` contract
- k8s: replace placeholder Cognito env vars with secret refs for `aarogya-web` app client (confidential, with secret)

## Deploy instructions
Before applying, replace `REPLACE_WITH_*` placeholders in `frontend-secret`:
\`\`\`bash
kubectl create secret generic frontend-secret -n aarogya-frontend \
  --from-literal=AUTH_SECRET=$(openssl rand -base64 32) \
  --from-literal=COGNITO_CLIENT_ID=XXXXX \
  --from-literal=COGNITO_CLIENT_SECRET=XXXXX \
  --dry-run=client -o yaml | kubectl apply -f -
\`\`\`

## Test plan
- [x] All 29 auth unit tests pass
- [x] ESLint clean
- [ ] E2E: Google sign-in → Cognito → callback → session established

🤖 Generated with [Claude Code](https://claude.com/claude-code)