### PR TITLE
feat(cd): inject Cognito secrets into k8s manifests via pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,13 +51,19 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.DEV_SSH_KEY }}
           IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+          COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
+          COGNITO_CLIENT_SECRET: ${{ secrets.COGNITO_CLIENT_SECRET }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
-          # Inject AUTH_SECRET into manifest before copying
-          sed -i "s|PLACEHOLDER_REPLACED_BY_CD|${AUTH_SECRET}|g" k8s/app.yaml
+          # Inject secrets into manifest before copying
+          sed -i \
+            -e "s|PLACEHOLDER_REPLACED_BY_CD|${AUTH_SECRET}|g" \
+            -e "s|REPLACE_WITH_WEB_CLIENT_ID|${COGNITO_CLIENT_ID}|g" \
+            -e "s|REPLACE_WITH_WEB_CLIENT_SECRET|${COGNITO_CLIENT_SECRET}|g" \
+            k8s/app.yaml
 
           ssh -o StrictHostKeyChecking=no sk@100.108.60.90 "mkdir -p ~/k8s-frontend"
           scp -o StrictHostKeyChecking=no k8s/*.yaml sk@100.108.60.90:~/k8s-frontend/


### PR DESCRIPTION
## Summary
- Extends the existing `sed` substitution in the CD pipeline to also inject Cognito client ID and secret into `k8s/app.yaml`
- Previously only `AUTH_SECRET` was substituted; now all three secret placeholders are covered

## GitHub Actions Secrets Required

| Secret | Description |
|--------|-------------|
| `AUTH_SECRET` | NextAuth session signing key (already exists) |
| `COGNITO_CLIENT_ID` | Web confidential client ID (`aarogya-web`) |
| `COGNITO_CLIENT_SECRET` | Web confidential client secret |

## Test plan
- [ ] Verify `app.yaml` placeholders match the `sed` patterns
- [ ] Add `COGNITO_CLIENT_ID` and `COGNITO_CLIENT_SECRET` secrets to GitHub repo settings
- [ ] Trigger a deploy and verify the frontend-secret has real values on the cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)