### PR TITLE
ci: add workflow_dispatch trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to CI workflow so it can be manually triggered from the Actions tab or `gh workflow run`

## Test plan
- [ ] Verify CI still triggers on push/PR as before
- [ ] Verify `gh workflow run ci.yml` works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)