### PR TITLE
feat(auth): switch to public Cognito client and add TLS ingress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,8 @@
 AUTH_SECRET=
 AUTH_URL=http://localhost:3000
 
-# AWS Cognito
+# AWS Cognito (public client — PKCE handles security, no secret needed)
 COGNITO_CLIENT_ID=
-COGNITO_CLIENT_SECRET=
 COGNITO_ISSUER=
 COGNITO_DOMAIN=
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,6 @@ jobs:
           IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
           COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
-          COGNITO_CLIENT_SECRET: ${{ secrets.COGNITO_CLIENT_SECRET }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
@@ -62,7 +61,6 @@ jobs:
           sed -i \
             -e "s|PLACEHOLDER_REPLACED_BY_CD|${AUTH_SECRET}|g" \
             -e "s|REPLACE_WITH_WEB_CLIENT_ID|${COGNITO_CLIENT_ID}|g" \
-            -e "s|REPLACE_WITH_WEB_CLIENT_SECRET|${COGNITO_CLIENT_SECRET}|g" \
             k8s/app.yaml
 
           ssh -o StrictHostKeyChecking=no sk@100.108.60.90 "mkdir -p ~/k8s-frontend"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,12 @@ ARG AUTH_SECRET=build-placeholder
 ARG COGNITO_DOMAIN=https://placeholder.auth.region.amazoncognito.com
 ARG COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_placeholder
 ARG COGNITO_CLIENT_ID=placeholder
-ARG COGNITO_CLIENT_SECRET=placeholder
 ARG API_URL=http://localhost:5000
 
 ENV AUTH_SECRET=$AUTH_SECRET \
     COGNITO_DOMAIN=$COGNITO_DOMAIN \
     COGNITO_ISSUER=$COGNITO_ISSUER \
     COGNITO_CLIENT_ID=$COGNITO_CLIENT_ID \
-    COGNITO_CLIENT_SECRET=$COGNITO_CLIENT_SECRET \
     API_URL=$API_URL
 
 RUN npm run build

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -7,7 +7,6 @@ type: Opaque
 stringData:
   AUTH_SECRET: "PLACEHOLDER_REPLACED_BY_CD"
   COGNITO_CLIENT_ID: "REPLACE_WITH_WEB_CLIENT_ID"
-  COGNITO_CLIENT_SECRET: "REPLACE_WITH_WEB_CLIENT_SECRET"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -41,7 +40,7 @@ spec:
                   name: frontend-secret
                   key: AUTH_SECRET
             - name: AUTH_URL
-              value: "http://dev.kinvee.in:30000"
+              value: "https://dev.kinvee.in"
             - name: API_URL
               value: "http://aarogya-api.aarogya.svc.cluster.local"
             - name: COGNITO_DOMAIN
@@ -53,11 +52,6 @@ spec:
                 secretKeyRef:
                   name: frontend-secret
                   key: COGNITO_CLIENT_ID
-            - name: COGNITO_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: frontend-secret
-                  key: COGNITO_CLIENT_SECRET
             - name: NEXT_PUBLIC_FIREBASE_API_KEY
               value: ""
             - name: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
@@ -98,10 +92,9 @@ metadata:
   labels:
     app: aarogya-frontend
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: aarogya-frontend
   ports:
     - port: 80
       targetPort: 3000
-      nodePort: 30000

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: aarogya-frontend-ingress
+  namespace: aarogya-frontend
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - dev.kinvee.in
+      secretName: frontend-tls
+  rules:
+    - host: dev.kinvee.in
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: aarogya-frontend
+                port:
+                  number: 80

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - app.yaml
+  - ingress.yaml

--- a/src/lib/auth/cognito-provider.test.ts
+++ b/src/lib/auth/cognito-provider.test.ts
@@ -8,7 +8,6 @@ beforeEach(() => {
   vi.stubEnv('COGNITO_DOMAIN', 'https://auth.example.com')
   vi.stubEnv('COGNITO_ISSUER', 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc')
   vi.stubEnv('COGNITO_CLIENT_ID', 'test-client-id')
-  vi.stubEnv('COGNITO_CLIENT_SECRET', 'test-client-secret')
   vi.stubEnv('API_URL', 'https://api.example.com')
 })
 
@@ -39,6 +38,11 @@ describe('CognitoPKCE provider', () => {
     expect(provider.userinfo).toEqual({
       url: 'https://auth.example.com/oauth2/userInfo',
     })
+  })
+
+  it('uses public client auth method (no client secret)', () => {
+    const provider = CognitoPKCE()
+    expect(provider.client).toEqual({ token_endpoint_auth_method: 'none' })
   })
 
   it('enables PKCE and state checks', () => {

--- a/src/lib/auth/cognito-provider.ts
+++ b/src/lib/auth/cognito-provider.ts
@@ -25,7 +25,6 @@ export default function CognitoPKCE(): OIDCConfig<CognitoProfile> {
     type: 'oidc',
     issuer: process.env.COGNITO_ISSUER,
     clientId: requireEnv('COGNITO_CLIENT_ID'),
-    clientSecret: requireEnv('COGNITO_CLIENT_SECRET'),
     authorization: {
       url: `${cognitoDomain}/oauth2/authorize`,
       params: { scope: 'openid email profile' },
@@ -35,6 +34,9 @@ export default function CognitoPKCE(): OIDCConfig<CognitoProfile> {
     },
     userinfo: {
       url: `${cognitoDomain}/oauth2/userInfo`,
+    },
+    client: {
+      token_endpoint_auth_method: 'none',
     },
     checks: ['pkce', 'state'],
     profile(profile, _tokens) {


### PR DESCRIPTION
## Summary
- Remove `COGNITO_CLIENT_SECRET` from auth provider, Dockerfile, CD pipeline, and k8s secrets — public Cognito client uses PKCE for security instead of a client secret
- Add `token_endpoint_auth_method: 'none'` to the OIDC provider config for public client compatibility
- Switch k8s Service from NodePort (30000) to ClusterIP, fronted by Traefik Ingress with TLS
- Add Ingress resource for `dev.kinvee.in` with cert-manager Let's Encrypt TLS
- Update `AUTH_URL` from `http://dev.kinvee.in:30000` to `https://dev.kinvee.in`

## Test plan
- [x] All 30 frontend tests pass locally
- [x] HTTPS verified working on cluster via Tailscale (`https://dev.kinvee.in` returns Next.js response)
- [ ] End-to-end Cognito OAuth flow (requires public port 443 forwarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)