### PR TITLE
fix(auth): force IPv4 DNS resolution for Cognito token exchange

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,14 +1,16 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const dns = await import('dns')
     // Force IPv4 DNS resolution — the cluster has no IPv6 internet connectivity,
     // causing Node.js built-in fetch (undici) to hang on AAAA records.
+
+    // Must use require() — ES module imports expose read-only getters.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dns = require('dns')
     dns.setDefaultResultOrder('ipv4first')
 
+    const origLookup = dns.lookup
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const origLookup = dns.lookup as any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    dns.lookup = ((...args: any[]) => {
+    dns.lookup = (...args: any[]) => {
       const [hostname, optionsOrCb, maybeCallback] = args
       if (typeof optionsOrCb === 'function') {
         return origLookup(hostname, { family: 4 }, optionsOrCb)
@@ -16,7 +18,6 @@ export async function register() {
       const opts =
         typeof optionsOrCb === 'number' ? { family: 4 } : { ...optionsOrCb, family: 4 }
       return origLookup(hostname, opts, maybeCallback)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Monkey-patches `dns.lookup` in `instrumentation.ts` to force `family: 4` on all DNS lookups
- Switches from `await import('dns')` (read-only ES module) to `require('dns')` (mutable CommonJS) so the patch can be applied
- Fixes ETIMEDOUT errors during Cognito OAuth token exchange caused by Node.js undici trying IPv6 AAAA records in an IPv4-only k3s cluster

## Context
The k3s cluster has no IPv6 internet connectivity. Node.js built-in `fetch` (undici) resolves DNS with Happy Eyeballs, trying IPv6 first. This causes the Cognito `/oauth2/token` call to hang and timeout during the NextAuth callback.

`NODE_OPTIONS=--dns-result-order=ipv4first` doesn't affect undici's internal DNS resolver. The only reliable fix is patching `dns.lookup` directly via Next.js instrumentation hooks.

## Test plan
- [ ] CI passes
- [ ] CD deploys successfully
- [ ] Google OAuth login completes without ETIMEDOUT
- [ ] Verify token exchange returns valid Cognito tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)