### PR TITLE
fix(settings): align profile types and endpoints with backend contracts

### DIFF
--- a/src/app/(portal)/settings/page.test.tsx
+++ b/src/app/(portal)/settings/page.test.tsx
@@ -21,18 +21,18 @@ function jsonResponse(data: unknown, status = 200) {
 }
 
 const mockProfile: Profile = {
-  id: 'u1',
-  name: 'Arjun Kumar',
+  sub: 'u1',
+  firstName: 'Arjun',
+  lastName: 'Kumar',
   email: 'arjun@example.com',
   phone: '9876543210',
   dateOfBirth: '1990-03-15T00:00:00Z',
   bloodGroup: 'B+',
   gender: 'male',
-  city: 'Bengaluru',
+  address: 'Bengaluru',
   aadhaarVerified: false,
-  avatarUrl: null,
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-06-01T00:00:00Z',
+  registrationStatus: 'approved',
+  roles: ['patient'],
 }
 
 const mockConsents: ConsentListResponse = {
@@ -159,13 +159,14 @@ describe('SettingsPage', () => {
     render(<SettingsPage />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('profile-name-input')).toHaveValue('Arjun Kumar')
+      expect(screen.getByTestId('profile-first-name-input')).toHaveValue('Arjun')
     })
+    expect(screen.getByTestId('profile-last-name-input')).toHaveValue('Kumar')
     expect(screen.getByTestId('profile-phone-input')).toHaveValue('9876543210')
     expect(screen.getByTestId('profile-dob-input')).toHaveValue('1990-03-15')
     expect(screen.getByTestId('profile-blood-group-select')).toHaveValue('B+')
     expect(screen.getByTestId('profile-gender-select')).toHaveValue('male')
-    expect(screen.getByTestId('profile-city-input')).toHaveValue('Bengaluru')
+    expect(screen.getByTestId('profile-address-input')).toHaveValue('Bengaluru')
   })
 
   it('shows Aadhaar not verified badge when unverified', async () => {
@@ -229,14 +230,14 @@ describe('SettingsPage', () => {
     render(<SettingsPage />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('profile-name-input')).toHaveValue('Arjun Kumar')
+      expect(screen.getByTestId('profile-first-name-input')).toHaveValue('Arjun')
     })
 
     const saveButton = screen.getByTestId('profile-save-button')
     expect(saveButton).toBeDisabled()
 
-    await userEvent.clear(screen.getByTestId('profile-name-input'))
-    await userEvent.type(screen.getByTestId('profile-name-input'), 'Arjun K')
+    await userEvent.clear(screen.getByTestId('profile-first-name-input'))
+    await userEvent.type(screen.getByTestId('profile-first-name-input'), 'Vikram')
 
     expect(saveButton).not.toBeDisabled()
   })
@@ -246,16 +247,16 @@ describe('SettingsPage', () => {
     render(<SettingsPage />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('profile-name-input')).toHaveValue('Arjun Kumar')
+      expect(screen.getByTestId('profile-first-name-input')).toHaveValue('Arjun')
     })
 
-    await userEvent.clear(screen.getByTestId('profile-name-input'))
-    await userEvent.type(screen.getByTestId('profile-name-input'), 'Arjun Patel')
+    await userEvent.clear(screen.getByTestId('profile-first-name-input'))
+    await userEvent.type(screen.getByTestId('profile-first-name-input'), 'Vikram')
 
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('/v1/consents')) return Promise.resolve(jsonResponse(mockConsents))
       if (url.includes('/v1/notification-preferences')) return Promise.resolve(jsonResponse(mockNotificationPrefs))
-      return Promise.resolve(jsonResponse({ ...mockProfile, name: 'Arjun Patel' }))
+      return Promise.resolve(jsonResponse({ ...mockProfile, firstName: 'Vikram' }))
     })
     await userEvent.click(screen.getByTestId('profile-save-button'))
 
@@ -269,15 +270,15 @@ describe('SettingsPage', () => {
     })
   })
 
-  it('shows validation error for empty name', async () => {
+  it('shows validation error for empty first name', async () => {
     setupFetchMock()
     render(<SettingsPage />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('profile-name-input')).toHaveValue('Arjun Kumar')
+      expect(screen.getByTestId('profile-first-name-input')).toHaveValue('Arjun')
     })
 
-    await userEvent.clear(screen.getByTestId('profile-name-input'))
+    await userEvent.clear(screen.getByTestId('profile-first-name-input'))
     await userEvent.click(screen.getByTestId('profile-save-button'))
 
     await waitFor(() => {

--- a/src/app/(portal)/settings/page.tsx
+++ b/src/app/(portal)/settings/page.tsx
@@ -18,12 +18,13 @@ export default function SettingsPage() {
   const handleSave = useCallback(
     (data: ProfileUpdate) => {
       updateProfile.mutate({
-        name: data.name,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        email: data.email,
         phone: data.phone,
         dateOfBirth: data.dateOfBirth,
         bloodGroup: data.bloodGroup || null,
-        gender: data.gender || null,
-        city: data.city || null,
+        address: data.address || null,
       })
     },
     [updateProfile],

--- a/src/components/settings/aadhaar-verify-dialog.test.tsx
+++ b/src/components/settings/aadhaar-verify-dialog.test.tsx
@@ -15,18 +15,30 @@ function jsonResponse(data: unknown, status = 200) {
 }
 
 const mockProfile: Profile = {
-  id: 'u1',
-  name: 'Arjun Kumar',
+  sub: 'u1',
+  firstName: 'Arjun',
+  lastName: 'Kumar',
   email: 'arjun@example.com',
   phone: '9876543210',
   dateOfBirth: '1990-03-15T00:00:00Z',
   bloodGroup: 'B+',
   gender: 'male',
-  city: 'Bengaluru',
+  address: 'Bengaluru',
   aadhaarVerified: false,
-  avatarUrl: null,
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-06-01T00:00:00Z',
+  registrationStatus: 'approved',
+  roles: ['patient'],
+}
+
+const mockVerificationResponse = {
+  referenceToken: 'ref-token-123',
+  existingRecord: false,
+  provider: 'uidai',
+  demographics: {
+    name: 'Arjun Kumar',
+    dateOfBirth: '1990-03-15',
+    gender: 'male',
+    address: 'Bengaluru, Karnataka',
+  },
 }
 
 const defaultProps = {
@@ -120,9 +132,7 @@ describe('AadhaarVerifyDialog', () => {
   })
 
   it('submits POST request with valid data', async () => {
-    mockFetch.mockResolvedValue(
-      jsonResponse({ verified: true, message: 'Aadhaar verified successfully' }),
-    )
+    mockFetch.mockResolvedValue(jsonResponse(mockVerificationResponse))
     const onClose = vi.fn()
 
     render(<AadhaarVerifyDialog {...defaultProps} onClose={onClose} />)
@@ -145,9 +155,7 @@ describe('AadhaarVerifyDialog', () => {
   })
 
   it('calls onClose after successful verification', async () => {
-    mockFetch.mockResolvedValue(
-      jsonResponse({ verified: true, message: 'Aadhaar verified successfully' }),
-    )
+    mockFetch.mockResolvedValue(jsonResponse(mockVerificationResponse))
     const onClose = vi.fn()
 
     render(<AadhaarVerifyDialog {...defaultProps} onClose={onClose} />)

--- a/src/components/settings/aadhaar-verify-dialog.tsx
+++ b/src/components/settings/aadhaar-verify-dialog.tsx
@@ -30,17 +30,6 @@ export interface AadhaarVerifyDialogProps {
   profile: Profile
 }
 
-function splitName(fullName: string): { firstName: string; lastName: string } {
-  const parts = fullName.trim().split(/\s+/)
-  if (parts.length <= 1) {
-    return { firstName: parts[0] ?? '', lastName: '' }
-  }
-  return {
-    firstName: parts.slice(0, -1).join(' '),
-    lastName: parts[parts.length - 1],
-  }
-}
-
 function formatDateForInput(dateStr: string): string {
   const d = new Date(dateStr)
   const year = d.getUTCFullYear()
@@ -68,11 +57,10 @@ export function AadhaarVerifyDialog({
 
   useEffect(() => {
     if (open) {
-      const { firstName, lastName } = splitName(profile.name)
       reset({
         aadhaarNumber: '',
-        firstName,
-        lastName,
+        firstName: profile.firstName,
+        lastName: profile.lastName,
         dateOfBirth: profile.dateOfBirth
           ? formatDateForInput(profile.dateOfBirth)
           : '',

--- a/src/components/settings/profile-section.tsx
+++ b/src/components/settings/profile-section.tsx
@@ -19,6 +19,7 @@ import { SettingsSection } from './settings-section'
 import { AadhaarVerifyDialog } from './aadhaar-verify-dialog'
 import type { ProfileUpdate } from '@/lib/schemas/profileUpdate'
 import type { Profile } from '@/types/profile'
+import { getDisplayName } from '@/types/profile'
 
 export interface ProfileSectionProps {
   profile: Profile | undefined
@@ -27,9 +28,9 @@ export interface ProfileSectionProps {
   onSave: (data: ProfileUpdate) => void
 }
 
-function getInitials(name: string): string {
-  return name
-    .split(' ')
+function getInitials(firstName: string, lastName: string): string {
+  const parts = [firstName, lastName].filter(Boolean)
+  return parts
     .slice(0, 2)
     .map((w) => w[0])
     .join('')
@@ -59,13 +60,14 @@ export function ProfileSection({ profile, isLoading, isSaving, onSave }: Profile
   useEffect(() => {
     if (profile) {
       reset({
-        name: profile.name,
+        firstName: profile.firstName,
+        lastName: profile.lastName,
         email: profile.email,
         phone: profile.phone,
         dateOfBirth: formatDateForInput(profile.dateOfBirth),
         bloodGroup: profile.bloodGroup,
         gender: profile.gender,
-        city: profile.city,
+        address: profile.address,
       })
     }
   }, [profile, reset])
@@ -117,11 +119,11 @@ export function ProfileSection({ profile, isLoading, isSaving, onSave }: Profile
           fontFamily="heading"
           fontSize="1.5rem"
         >
-          {getInitials(profile.name)}
+          {getInitials(profile.firstName, profile.lastName)}
         </Flex>
         <Box>
           <Text fontWeight="semibold" fontSize="1.25rem" color="text.primary">
-            {profile.name}
+            {getDisplayName(profile)}
           </Text>
           <Text fontSize="0.9rem" color="text.muted" mt="0.5">
             {profile.email}
@@ -135,21 +137,39 @@ export function ProfileSection({ profile, isLoading, isSaving, onSave }: Profile
         gridTemplateColumns={{ base: '1fr', md: '1fr 1fr' }}
         gap="5"
       >
-        {/* Full Name */}
-        <Field.Root invalid={!!errors.name} required>
+        {/* First Name */}
+        <Field.Root invalid={!!errors.firstName} required>
           <Field.Label color="text.secondary" fontSize="0.875rem" fontWeight="medium">
-            Full Name
+            First Name
           </Field.Label>
           <Input
-            {...register('name')}
+            {...register('firstName')}
             bg="bg.glass"
             borderColor="border.default"
             borderRadius="xl"
             color="text.primary"
-            data-testid="profile-name-input"
+            data-testid="profile-first-name-input"
           />
-          {errors.name && (
-            <Field.ErrorText>{errors.name.message}</Field.ErrorText>
+          {errors.firstName && (
+            <Field.ErrorText>{errors.firstName.message}</Field.ErrorText>
+          )}
+        </Field.Root>
+
+        {/* Last Name */}
+        <Field.Root invalid={!!errors.lastName} required>
+          <Field.Label color="text.secondary" fontSize="0.875rem" fontWeight="medium">
+            Last Name
+          </Field.Label>
+          <Input
+            {...register('lastName')}
+            bg="bg.glass"
+            borderColor="border.default"
+            borderRadius="xl"
+            color="text.primary"
+            data-testid="profile-last-name-input"
+          />
+          {errors.lastName && (
+            <Field.ErrorText>{errors.lastName.message}</Field.ErrorText>
           )}
         </Field.Root>
 
@@ -271,18 +291,18 @@ export function ProfileSection({ profile, isLoading, isSaving, onSave }: Profile
           )}
         </Field.Root>
 
-        {/* Gender */}
+        {/* Gender (display only — backend doesn't accept updates) */}
         <Field.Root invalid={!!errors.gender}>
           <Field.Label color="text.secondary" fontSize="0.875rem" fontWeight="medium">
             Gender
           </Field.Label>
-          <NativeSelect.Root>
+          <NativeSelect.Root disabled>
             <NativeSelect.Field
               {...register('gender')}
-              bg="bg.glass"
+              bg="bg.overlay"
               borderColor="border.default"
               borderRadius="xl"
-              color="text.primary"
+              color="text.muted"
               data-testid="profile-gender-select"
             >
               <option value="">Select</option>
@@ -299,21 +319,21 @@ export function ProfileSection({ profile, isLoading, isSaving, onSave }: Profile
           )}
         </Field.Root>
 
-        {/* City */}
-        <Field.Root invalid={!!errors.city}>
+        {/* Address */}
+        <Field.Root invalid={!!errors.address}>
           <Field.Label color="text.secondary" fontSize="0.875rem" fontWeight="medium">
-            City
+            Address
           </Field.Label>
           <Input
-            {...register('city')}
+            {...register('address')}
             bg="bg.glass"
             borderColor="border.default"
             borderRadius="xl"
             color="text.primary"
-            data-testid="profile-city-input"
+            data-testid="profile-address-input"
           />
-          {errors.city && (
-            <Field.ErrorText>{errors.city.message}</Field.ErrorText>
+          {errors.address && (
+            <Field.ErrorText>{errors.address.message}</Field.ErrorText>
           )}
         </Field.Root>
       </Box>

--- a/src/hooks/profile/use-profile.test.tsx
+++ b/src/hooks/profile/use-profile.test.tsx
@@ -17,18 +17,18 @@ function jsonResponse(data: unknown, status = 200) {
 }
 
 const mockProfile: Profile = {
-  id: 'u1',
-  name: 'Arjun Kumar',
+  sub: 'u1',
+  firstName: 'Arjun',
+  lastName: 'Kumar',
   email: 'arjun@example.com',
   phone: '9876543210',
   dateOfBirth: '1990-03-15T00:00:00Z',
   bloodGroup: 'B+',
   gender: 'male',
-  city: 'Bengaluru',
+  address: 'Bengaluru',
   aadhaarVerified: false,
-  avatarUrl: null,
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-06-01T00:00:00Z',
+  registrationStatus: 'approved',
+  roles: ['patient'],
 }
 
 function createWrapper() {
@@ -51,7 +51,7 @@ beforeEach(() => {
 })
 
 describe('useProfile', () => {
-  it('fetches profile from /v1/profile', async () => {
+  it('fetches profile from /v1/users/me', async () => {
     mockFetch.mockResolvedValue(jsonResponse(mockProfile))
 
     const { result } = renderHook(() => useProfile(), {
@@ -63,7 +63,7 @@ describe('useProfile', () => {
     expect(result.current.data).toEqual(mockProfile)
 
     const calledUrl = mockFetch.mock.calls[0][0] as string
-    expect(calledUrl).toContain('/v1/profile')
+    expect(calledUrl).toContain('/v1/users/me')
   })
 
   it('returns error on failure', async () => {

--- a/src/hooks/profile/use-profile.ts
+++ b/src/hooks/profile/use-profile.ts
@@ -7,7 +7,7 @@ import type { Profile } from '@/types/profile'
 export function useProfile() {
   return useQuery({
     queryKey: queryKeys.profile.me(),
-    queryFn: () => apiFetch<Profile>('/v1/profile'),
+    queryFn: () => apiFetch<Profile>('/v1/users/me'),
     staleTime: staleTimes.profile,
   })
 }

--- a/src/hooks/profile/use-update-profile.test.tsx
+++ b/src/hooks/profile/use-update-profile.test.tsx
@@ -18,18 +18,18 @@ function jsonResponse(data: unknown, status = 200) {
 }
 
 const mockProfile: Profile = {
-  id: 'u1',
-  name: 'Arjun Kumar',
+  sub: 'u1',
+  firstName: 'Arjun',
+  lastName: 'Kumar',
   email: 'arjun@example.com',
   phone: '9876543210',
   dateOfBirth: '1990-03-15',
   bloodGroup: 'B+',
   gender: 'male',
-  city: 'Bengaluru',
+  address: 'Bengaluru',
   aadhaarVerified: false,
-  avatarUrl: null,
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-06-01T00:00:00Z',
+  registrationStatus: 'approved',
+  roles: ['patient'],
 }
 
 let queryClient: QueryClient
@@ -55,7 +55,7 @@ beforeEach(() => {
 
 describe('useUpdateProfile', () => {
   it('sends PUT request with profile data', async () => {
-    const updated = { ...mockProfile, name: 'Arjun Patel' }
+    const updated = { ...mockProfile, firstName: 'Arjun', lastName: 'Patel' }
     mockFetch.mockResolvedValue(jsonResponse(updated))
 
     const { result } = renderHook(() => useUpdateProfile(), {
@@ -64,19 +64,20 @@ describe('useUpdateProfile', () => {
 
     await act(() =>
       result.current.mutateAsync({
-        name: 'Arjun Patel',
+        firstName: 'Arjun',
+        lastName: 'Patel',
+        email: 'arjun@example.com',
         phone: '9876543210',
         dateOfBirth: '1990-03-15',
         bloodGroup: 'B+',
-        gender: 'male',
-        city: 'Bengaluru',
+        address: 'Bengaluru',
       }),
     )
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     const calledUrl = mockFetch.mock.calls[0][0] as string
-    expect(calledUrl).toContain('/v1/profile')
+    expect(calledUrl).toContain('/v1/users/me')
 
     const calledInit = mockFetch.mock.calls[0][1] as RequestInit
     expect(calledInit.method).toBe('PUT')
@@ -91,7 +92,7 @@ describe('useUpdateProfile', () => {
     mockFetch.mockReturnValue(
       new Promise<Response>((resolve) => {
         resolveUpdate = () =>
-          resolve(jsonResponse({ ...mockProfile, name: 'Arjun Patel' }))
+          resolve(jsonResponse({ ...mockProfile, lastName: 'Patel' }))
       }),
     )
 
@@ -99,18 +100,19 @@ describe('useUpdateProfile', () => {
 
     await act(async () => {
       result.current.mutate({
-        name: 'Arjun Patel',
+        firstName: 'Arjun',
+        lastName: 'Patel',
+        email: 'arjun@example.com',
         phone: '9876543210',
         dateOfBirth: '1990-03-15',
         bloodGroup: 'B+',
-        gender: 'male',
-        city: 'Bengaluru',
+        address: 'Bengaluru',
       })
     })
 
     await waitFor(() => {
       const cached = queryClient.getQueryData<Profile>(queryKeys.profile.me())
-      expect(cached?.name).toBe('Arjun Patel')
+      expect(cached?.lastName).toBe('Patel')
     })
 
     await act(async () => {
@@ -129,18 +131,19 @@ describe('useUpdateProfile', () => {
 
     await act(async () => {
       result.current.mutate({
-        name: 'Arjun Patel',
+        firstName: 'Arjun',
+        lastName: 'Patel',
+        email: 'arjun@example.com',
         phone: '9876543210',
         dateOfBirth: '1990-03-15',
         bloodGroup: 'B+',
-        gender: 'male',
-        city: 'Bengaluru',
+        address: 'Bengaluru',
       })
     })
 
     await waitFor(() => expect(result.current.isError).toBe(true))
 
     const cached = queryClient.getQueryData<Profile>(queryKeys.profile.me())
-    expect(cached?.name).toBe('Arjun Kumar')
+    expect(cached?.lastName).toBe('Kumar')
   })
 })

--- a/src/hooks/profile/use-update-profile.ts
+++ b/src/hooks/profile/use-update-profile.ts
@@ -8,7 +8,7 @@ export function useUpdateProfile() {
 
   return useMutation({
     mutationFn: (request: UpdateProfileRequest) =>
-      apiFetch<Profile>('/v1/profile', {
+      apiFetch<Profile>('/v1/users/me', {
         method: 'PUT',
         body: request,
       }),
@@ -24,7 +24,6 @@ export function useUpdateProfile() {
         return {
           ...old,
           ...request,
-          updatedAt: new Date().toISOString(),
         }
       })
 

--- a/src/hooks/profile/use-verify-aadhaar.test.tsx
+++ b/src/hooks/profile/use-verify-aadhaar.test.tsx
@@ -18,18 +18,18 @@ function jsonResponse(data: unknown, status = 200) {
 }
 
 const mockProfile: Profile = {
-  id: 'u1',
-  name: 'Arjun Kumar',
+  sub: 'u1',
+  firstName: 'Arjun',
+  lastName: 'Kumar',
   email: 'arjun@example.com',
   phone: '9876543210',
   dateOfBirth: '1990-03-15',
   bloodGroup: 'B+',
   gender: 'male',
-  city: 'Bengaluru',
+  address: 'Bengaluru',
   aadhaarVerified: false,
-  avatarUrl: null,
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-06-01T00:00:00Z',
+  registrationStatus: 'approved',
+  roles: ['patient'],
 }
 
 const validRequest = {
@@ -37,6 +37,18 @@ const validRequest = {
   firstName: 'Arjun',
   lastName: 'Kumar',
   dateOfBirth: '1990-03-15',
+}
+
+const mockVerificationResponse = {
+  referenceToken: 'ref-token-123',
+  existingRecord: false,
+  provider: 'uidai',
+  demographics: {
+    name: 'Arjun Kumar',
+    dateOfBirth: '1990-03-15',
+    gender: 'male',
+    address: 'Bengaluru, Karnataka',
+  },
 }
 
 let queryClient: QueryClient
@@ -61,10 +73,8 @@ beforeEach(() => {
 })
 
 describe('useVerifyAadhaar', () => {
-  it('sends POST request to /v1/profile/aadhaar/verify', async () => {
-    mockFetch.mockResolvedValue(
-      jsonResponse({ verified: true, message: 'Aadhaar verified successfully' }),
-    )
+  it('sends POST request to /v1/users/me/aadhaar/verify', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockVerificationResponse))
 
     const { result } = renderHook(() => useVerifyAadhaar(), {
       wrapper: createWrapper(),
@@ -75,7 +85,7 @@ describe('useVerifyAadhaar', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     const calledUrl = mockFetch.mock.calls[0][0] as string
-    expect(calledUrl).toContain('/v1/profile/aadhaar/verify')
+    expect(calledUrl).toContain('/v1/users/me/aadhaar/verify')
 
     const calledInit = mockFetch.mock.calls[0][1] as RequestInit
     expect(calledInit.method).toBe('POST')
@@ -86,9 +96,7 @@ describe('useVerifyAadhaar', () => {
 
     queryClient.setQueryData(queryKeys.profile.me(), mockProfile)
 
-    mockFetch.mockResolvedValue(
-      jsonResponse({ verified: true, message: 'Aadhaar verified successfully' }),
-    )
+    mockFetch.mockResolvedValue(jsonResponse(mockVerificationResponse))
 
     const { result } = renderHook(() => useVerifyAadhaar(), { wrapper })
 

--- a/src/hooks/profile/use-verify-aadhaar.ts
+++ b/src/hooks/profile/use-verify-aadhaar.ts
@@ -12,7 +12,7 @@ export function useVerifyAadhaar() {
 
   return useMutation({
     mutationFn: (request: VerifyAadhaarRequest) =>
-      apiFetch<AadhaarVerificationResponse>('/v1/profile/aadhaar/verify', {
+      apiFetch<AadhaarVerificationResponse>('/v1/users/me/aadhaar/verify', {
         method: 'POST',
         body: request,
       }),
@@ -22,7 +22,6 @@ export function useVerifyAadhaar() {
         return {
           ...old,
           aadhaarVerified: true,
-          updatedAt: new Date().toISOString(),
         }
       })
     },

--- a/src/lib/schemas/profileUpdate.test.ts
+++ b/src/lib/schemas/profileUpdate.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { profileUpdateSchema } from './profileUpdate'
 
 const validData = {
-  name: 'Amit Patel',
+  firstName: 'Amit',
+  lastName: 'Patel',
   email: 'amit@example.com',
   phone: '9876543210',
   dateOfBirth: '1990-05-15',
@@ -48,18 +49,34 @@ describe('profileUpdateSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects empty name', () => {
+  it('rejects empty first name', () => {
     const result = profileUpdateSchema.safeParse({
       ...validData,
-      name: '',
+      firstName: '',
     })
     expect(result.success).toBe(false)
   })
 
-  it('rejects name exceeding 100 characters', () => {
+  it('rejects first name exceeding 120 characters', () => {
     const result = profileUpdateSchema.safeParse({
       ...validData,
-      name: 'a'.repeat(101),
+      firstName: 'a'.repeat(121),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty last name', () => {
+    const result = profileUpdateSchema.safeParse({
+      ...validData,
+      lastName: '',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects last name exceeding 120 characters', () => {
+    const result = profileUpdateSchema.safeParse({
+      ...validData,
+      lastName: 'a'.repeat(121),
     })
     expect(result.success).toBe(false)
   })
@@ -112,18 +129,18 @@ describe('profileUpdateSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('accepts valid city', () => {
+  it('accepts valid address', () => {
     const result = profileUpdateSchema.safeParse({
       ...validData,
-      city: 'Bengaluru',
+      address: 'Bengaluru',
     })
     expect(result.success).toBe(true)
   })
 
-  it('rejects city exceeding 100 characters', () => {
+  it('rejects address exceeding 500 characters', () => {
     const result = profileUpdateSchema.safeParse({
       ...validData,
-      city: 'a'.repeat(101),
+      address: 'a'.repeat(501),
     })
     expect(result.success).toBe(false)
   })

--- a/src/lib/schemas/profileUpdate.ts
+++ b/src/lib/schemas/profileUpdate.ts
@@ -7,7 +7,8 @@ const bloodGroupValues = ['A+', 'A-', 'B+', 'B-', 'AB+', 'AB-', 'O+', 'O-'] as c
 const genderValues = ['male', 'female', 'other'] as const
 
 export const profileUpdateSchema = z.object({
-  name: nonEmptyString.max(100, 'Name must be 100 characters or fewer'),
+  firstName: nonEmptyString.max(120, 'First name must be 120 characters or fewer'),
+  lastName: nonEmptyString.max(120, 'Last name must be 120 characters or fewer'),
   email: email,
   phone: phoneNumber,
   dateOfBirth: z
@@ -16,7 +17,7 @@ export const profileUpdateSchema = z.object({
     .refine((s) => new Date(s) < new Date(), 'Must be in the past'),
   bloodGroup: z.enum(bloodGroupValues).nullable().optional(),
   gender: z.enum(genderValues).nullable().optional(),
-  city: z.string().trim().max(100, 'City must be 100 characters or fewer').nullable().optional(),
+  address: z.string().trim().max(500, 'Address must be 500 characters or fewer').nullable().optional(),
 })
 
 export type ProfileUpdate = z.infer<typeof profileUpdateSchema>

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -2,28 +2,31 @@ export type BloodGroup = 'A+' | 'A-' | 'B+' | 'B-' | 'AB+' | 'AB-' | 'O+' | 'O-'
 
 export type Gender = 'male' | 'female' | 'other'
 
+export type RegistrationStatus = 'pending_approval' | 'approved' | 'rejected'
+
 export interface Profile {
-  id: string
-  name: string
+  sub: string
+  firstName: string
+  lastName: string
   email: string
   phone: string
   dateOfBirth: string
   bloodGroup: BloodGroup | null
   gender: Gender | null
-  city: string | null
+  address: string | null
   aadhaarVerified: boolean
-  avatarUrl: string | null
-  createdAt: string
-  updatedAt: string
+  registrationStatus: RegistrationStatus
+  roles: string[]
 }
 
 export interface UpdateProfileRequest {
-  name: string
+  firstName: string
+  lastName: string
+  email: string
   phone: string
   dateOfBirth: string
   bloodGroup: BloodGroup | null
-  gender: Gender | null
-  city: string | null
+  address: string | null
 }
 
 export interface VerifyAadhaarRequest {
@@ -33,7 +36,20 @@ export interface VerifyAadhaarRequest {
   dateOfBirth: string
 }
 
+export interface AadhaarDemographics {
+  name: string
+  dateOfBirth: string
+  gender: string
+  address: string
+}
+
 export interface AadhaarVerificationResponse {
-  verified: boolean
-  message: string
+  referenceToken: string
+  existingRecord: boolean
+  provider: string
+  demographics: AadhaarDemographics
+}
+
+export function getDisplayName(profile: Pick<Profile, 'firstName' | 'lastName'>): string {
+  return [profile.firstName, profile.lastName].filter(Boolean).join(' ')
 }


### PR DESCRIPTION
## Summary
- Aligns all frontend profile types, API endpoints, and UI fields with backend changes from PRs #248 (RegistrationRequiredMiddleware) and #250 (Aadhaar demographics)
- Moves API endpoints from `/v1/profile` to `/v1/users/me` (profile fetch, update, Aadhaar verify)
- Splits single "Full Name" field into separate "First Name" / "Last Name" fields, renames "City" to "Address", disables Gender (backend no longer accepts updates)
- Updates `AadhaarVerificationResponse` to match new backend contract (`referenceToken`, `existingRecord`, `provider`, `demographics`)

### Files changed (14)
**Source (8):** `profile.ts` types, `profileUpdate.ts` schema, 3 hooks (`use-profile`, `use-update-profile`, `use-verify-aadhaar`), `profile-section.tsx`, `aadhaar-verify-dialog.tsx`, `settings/page.tsx`

**Tests (6):** All corresponding test files updated with new mock shapes, endpoint assertions, and field test IDs

## Test plan
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors
- [x] `npm run test` — 115 files, 1025 tests pass
- [x] `npm run build` — production build succeeds
- [x] Browser verification: profile fields render correctly, form editing enables Save, Aadhaar dialog pre-populates from `firstName`/`lastName`, all API calls hit new `/v1/users/me` endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)