### PR TITLE
fix(auth): harden auth flow with nonce check, 401 redirect, and proxy secret

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -16,7 +16,7 @@ async function proxyRequest(
     )
   }
 
-  const token = await getToken({ req: request })
+  const token = await getToken({ req: request, secret: process.env.AUTH_SECRET })
 
   if (!token || token.error === 'RefreshTokenError') {
     return NextResponse.json(

--- a/src/lib/api/client.test.ts
+++ b/src/lib/api/client.test.ts
@@ -220,6 +220,67 @@ describe('apiFetch', () => {
     expect(onResponse).toHaveBeenCalledWith(res)
   })
 
+  describe('401 session redirect', () => {
+    const originalWindow = globalThis.window
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        value: {
+          location: {
+            pathname: '/reports',
+            href: '/reports',
+          },
+        },
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        value: originalWindow,
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    it('redirects to /login with callbackUrl on 401', async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({ message: 'Authentication required' }, 401),
+      )
+
+      const error = await apiFetch('/v1/reports').catch((e) => e)
+      expect(error).toBeInstanceOf(ApiError)
+      expect(error).toMatchObject({ status: 401 })
+      expect(window.location.href).toBe('/login?callbackUrl=%2Freports')
+    })
+
+    it('encodes nested pathname in callbackUrl', async () => {
+      window.location.pathname = '/settings/profile'
+
+      mockFetch.mockResolvedValue(
+        jsonResponse({ message: 'Authentication required' }, 401),
+      )
+
+      const error = await apiFetch('/v1/users/me').catch((e) => e)
+      expect(error).toBeInstanceOf(ApiError)
+      expect(window.location.href).toBe('/login?callbackUrl=%2Fsettings%2Fprofile')
+    })
+
+    it('does not redirect when already on /login', async () => {
+      window.location.pathname = '/login'
+      window.location.href = '/login'
+
+      mockFetch.mockResolvedValue(
+        jsonResponse({ message: 'Authentication required' }, 401),
+      )
+
+      const error = await apiFetch('/v1/users/me').catch((e) => e)
+      expect(error).toBeInstanceOf(ApiError)
+      expect(window.location.href).toBe('/login')
+    })
+  })
+
   describe('403 registration redirects', () => {
     const originalWindow = globalThis.window
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -76,6 +76,14 @@ export async function apiFetch<T>(
       // use statusText
     }
 
+    if (response.status === 401 && typeof window !== 'undefined') {
+      const pathname = window.location.pathname
+      if (pathname !== '/login') {
+        window.location.href = `/login?callbackUrl=${encodeURIComponent(pathname)}`
+      }
+      throw new ApiError(response.status, message, code)
+    }
+
     if (response.status === 403 && code && typeof window !== 'undefined') {
       const pathname = window.location.pathname
       const isRegistrationRoute = pathname.startsWith('/register')

--- a/src/lib/auth/cognito-provider.test.ts
+++ b/src/lib/auth/cognito-provider.test.ts
@@ -47,7 +47,7 @@ describe('CognitoPKCE provider', () => {
 
   it('enables PKCE and state checks', () => {
     const provider = CognitoPKCE()
-    expect(provider.checks).toEqual(['pkce', 'state'])
+    expect(provider.checks).toEqual(['pkce', 'state', 'nonce'])
   })
 
   it('maps profile correctly', () => {

--- a/src/lib/auth/cognito-provider.ts
+++ b/src/lib/auth/cognito-provider.ts
@@ -38,7 +38,7 @@ export default function CognitoPKCE(): OIDCConfig<CognitoProfile> {
     client: {
       token_endpoint_auth_method: 'none',
     },
-    checks: ['pkce', 'state'],
+    checks: ['pkce', 'state', 'nonce'],
     profile(profile, _tokens) {
       return {
         id: profile.sub,


### PR DESCRIPTION
## Summary
- Add `nonce` to OIDC checks for Cognito PKCE provider — fixes `unexpected ID Token "nonce" claim value` error on Google social login
- Pass `AUTH_SECRET` explicitly to `getToken()` in BFF proxy route — fixes `MissingSecret` error causing all proxied API calls to return 500
- Redirect to `/login?callbackUrl=...` on 401 API responses — prevents blank pages when sessions expire (RegistrationGate returned null on error)

## Test plan
- [x] All 1028 unit tests pass
- [x] Type check clean
- [x] Lint clean (only pre-existing warnings)
- [ ] Verify Google sign-in works on localhost:3000
- [ ] Verify API proxy calls succeed after login (registration-status, reports)
- [ ] Verify expired session redirects to /login instead of blank page

🤖 Generated with [Claude Code](https://claude.com/claude-code)