### PR TITLE
fix(notifications): correct device registration endpoint URL

### DIFF
--- a/src/components/settings/notifications-section.test.tsx
+++ b/src/components/settings/notifications-section.test.tsx
@@ -175,7 +175,7 @@ describe('NotificationsSection', () => {
     })
 
     mockFetch.mockImplementation((url: string, opts?: RequestInit) => {
-      if (opts?.method === 'POST' && (url as string).includes('device-token')) {
+      if (opts?.method === 'POST' && (url as string).includes('notifications/devices')) {
         return Promise.resolve(new Response(null, { status: 204, headers: { 'content-length': '0' } }))
       }
       return Promise.resolve(jsonResponse({ ...mockPrefs, push: { ...mockPrefs.push, enabled: true } }))
@@ -187,11 +187,11 @@ describe('NotificationsSection', () => {
       const postCalls = mockFetch.mock.calls.filter((call) => {
         const url = call[0] as string
         const opts = call[1] as RequestInit | undefined
-        return url.includes('device-token') && opts?.method === 'POST'
+        return url.includes('notifications/devices') && opts?.method === 'POST'
       })
       expect(postCalls).toHaveLength(1)
       const body = JSON.parse(postCalls[0][1].body as string)
-      expect(body.token).toBe('fcm-token-abc')
+      expect(body.deviceToken).toBe('fcm-token-abc')
     })
   })
 

--- a/src/components/settings/notifications-section.tsx
+++ b/src/components/settings/notifications-section.tsx
@@ -44,7 +44,7 @@ export function NotificationsSection() {
       if (channel === 'push' && enabled) {
         const result = await requestPushPermission()
         if (result.status !== 'granted') return
-        registerToken.mutate({ token: result.token, platform: 'web' })
+        registerToken.mutate({ deviceToken: result.token, platform: 'web' })
       }
 
       const currentChannel = prefs[channel]

--- a/src/hooks/notifications/use-register-device-token.test.tsx
+++ b/src/hooks/notifications/use-register-device-token.test.tsx
@@ -48,19 +48,29 @@ describe('useRegisterDeviceToken', () => {
     })
 
     await act(() =>
-      result.current.mutateAsync({ token: 'fcm-token-123', platform: 'web' }),
+      result.current.mutateAsync({
+        deviceToken: 'fcm-token-123',
+        platform: 'web',
+        deviceName: 'Chrome 120',
+        appVersion: '1.0.0',
+      }),
     )
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     const calledUrl = mockFetch.mock.calls[0][0] as string
-    expect(calledUrl).toContain('/v1/notification-preferences/device-token')
+    expect(calledUrl).toContain('/v1/notifications/devices')
 
     const calledInit = mockFetch.mock.calls[0][1] as RequestInit
     expect(calledInit.method).toBe('POST')
 
     const body = JSON.parse(calledInit.body as string)
-    expect(body).toEqual({ token: 'fcm-token-123', platform: 'web' })
+    expect(body).toEqual({
+      deviceToken: 'fcm-token-123',
+      platform: 'web',
+      deviceName: 'Chrome 120',
+      appVersion: '1.0.0',
+    })
   })
 
   it('returns error state on failure', async () => {
@@ -73,7 +83,7 @@ describe('useRegisterDeviceToken', () => {
     })
 
     await act(async () => {
-      result.current.mutate({ token: 'bad-token', platform: 'web' })
+      result.current.mutate({ deviceToken: 'bad-token', platform: 'web' })
     })
 
     await waitFor(() => expect(result.current.isError).toBe(true))

--- a/src/hooks/notifications/use-register-device-token.ts
+++ b/src/hooks/notifications/use-register-device-token.ts
@@ -5,7 +5,7 @@ import type { DeviceTokenRequest } from '@/types/notification'
 export function useRegisterDeviceToken() {
   return useMutation({
     mutationFn: (request: DeviceTokenRequest) =>
-      apiFetch<void>('/v1/notification-preferences/device-token', {
+      apiFetch<void>('/v1/notifications/devices', {
         method: 'POST',
         body: request,
       }),

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -20,6 +20,8 @@ export interface UpdateNotificationPrefsRequest {
 }
 
 export interface DeviceTokenRequest {
-  token: string
+  deviceToken: string
   platform: 'web'
+  deviceName?: string
+  appVersion?: string
 }


### PR DESCRIPTION
## Summary
- Fixed `useRegisterDeviceToken` hook calling wrong endpoint (`/v1/notification-preferences/device-token` -> `/v1/notifications/devices`)
- Aligned `DeviceTokenRequest` type with backend `RegisterDeviceTokenRequest` contract: renamed `token` to `deviceToken`, added optional `deviceName` and `appVersion` fields
- Updated all consumers and tests to match new endpoint and request shape

Closes #102

## Test plan
- [x] `npm run type-check` passes with zero errors
- [x] All 1028 tests pass (`npm run test`)
- [ ] Verify device token registration works end-to-end in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)