### PR TITLE
feat(access-grants): align AccessGrant type and CreateAccessGrantRequest with backend contract

### DIFF
--- a/src/app/(portal)/access/page.test.tsx
+++ b/src/app/(portal)/access/page.test.tsx
@@ -16,37 +16,66 @@ function jsonResponse(data: unknown, status = 200) {
 }
 
 const activeGrant = {
-  id: 'g1',
-  doctorId: 'd1',
+  grantId: 'g1',
+  patientSub: 'p1',
+  doctorSub: 'd1',
   doctorName: 'Dr. Priya Sharma',
+  allReports: false,
   reportIds: ['r1', 'r2', 'r3'],
+  purpose: 'Blood test review',
+  startsAt: '2025-01-01T00:00:00Z',
   expiresAt: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+  revoked: false,
   createdAt: '2025-01-01T00:00:00Z',
 }
 
 const expiringGrant = {
-  id: 'g2',
-  doctorId: 'd2',
+  grantId: 'g2',
+  patientSub: 'p1',
+  doctorSub: 'd2',
   doctorName: 'Dr. Rajesh Kumar',
-  reportIds: ['r1'],
+  allReports: true,
+  reportIds: [],
+  purpose: 'Ongoing treatment',
+  startsAt: '2025-01-10T00:00:00Z',
   expiresAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+  revoked: false,
   createdAt: '2025-01-10T00:00:00Z',
 }
 
 const expiredGrant = {
-  id: 'g3',
-  doctorId: 'd3',
+  grantId: 'g3',
+  patientSub: 'p1',
+  doctorSub: 'd3',
   doctorName: 'Dr. Anita Desai',
+  allReports: false,
   reportIds: ['r2'],
+  purpose: 'X-ray analysis',
+  startsAt: '2024-12-01T00:00:00Z',
   expiresAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+  revoked: false,
   createdAt: '2024-12-01T00:00:00Z',
 }
 
+const revokedGrant = {
+  grantId: 'g4',
+  patientSub: 'p1',
+  doctorSub: 'd4',
+  doctorName: 'Dr. Vikram Patel',
+  allReports: false,
+  reportIds: ['r1'],
+  purpose: 'Second opinion',
+  startsAt: '2025-01-05T00:00:00Z',
+  expiresAt: new Date(Date.now() + 20 * 24 * 60 * 60 * 1000).toISOString(),
+  revoked: true,
+  createdAt: '2025-01-05T00:00:00Z',
+}
+
 const mockGrantData: AccessGrantListResponse = {
-  items: [activeGrant, expiringGrant, expiredGrant],
+  items: [activeGrant, expiringGrant, expiredGrant, revokedGrant],
   page: 1,
   pageSize: 20,
-  totalCount: 3,
+  totalCount: 4,
   totalPages: 1,
 }
 
@@ -122,7 +151,7 @@ describe('AccessPage', () => {
     expect(screen.getByTestId('access-loading')).toBeInTheDocument()
   })
 
-  it('renders active and expired grant sections', async () => {
+  it('renders active and inactive grant sections', async () => {
     mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
     render(<AccessPage />)
 
@@ -131,9 +160,10 @@ describe('AccessPage', () => {
     })
 
     expect(screen.getByText('Active Grants')).toBeInTheDocument()
-    expect(screen.getByText('Expired Grants')).toBeInTheDocument()
+    expect(screen.getByText('Inactive Grants')).toBeInTheDocument()
     expect(screen.getByText('Dr. Rajesh Kumar')).toBeInTheDocument()
     expect(screen.getByText('Dr. Anita Desai')).toBeInTheDocument()
+    expect(screen.getByText('Dr. Vikram Patel')).toBeInTheDocument()
   })
 
   it('renders page heading and Grant Access button', async () => {
@@ -162,11 +192,11 @@ describe('AccessPage', () => {
     render(<AccessPage />)
 
     await waitFor(() => {
-      expect(screen.getAllByTestId('grant-card')).toHaveLength(3)
+      expect(screen.getAllByTestId('grant-card')).toHaveLength(4)
     })
   })
 
-  it('shows active/expiring/expired status badges', async () => {
+  it('shows active/expiring/expired/revoked status badges', async () => {
     mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
     render(<AccessPage />)
 
@@ -175,6 +205,17 @@ describe('AccessPage', () => {
     })
     expect(screen.getByText('Expiring Soon')).toBeInTheDocument()
     expect(screen.getByText('Expired')).toBeInTheDocument()
+    expect(screen.getByText('Revoked')).toBeInTheDocument()
+  })
+
+  it('shows "All reports" for grants with allReports flag', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Rajesh Kumar')).toBeInTheDocument()
+    })
+    expect(screen.getByText('All reports')).toBeInTheDocument()
   })
 
   it('opens revoke dialog when Revoke is clicked', async () => {
@@ -276,5 +317,18 @@ describe('AccessPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Grant Doctor Access')).toBeInTheDocument()
     })
+  })
+
+  it('does not show revoke button for revoked grants', async () => {
+    mockFetch.mockImplementation((url: string) => Promise.resolve(mockFetchHandler(url)))
+    render(<AccessPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Dr. Vikram Patel')).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole('button', { name: /revoke access for dr\. vikram patel/i }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/app/(portal)/access/page.tsx
+++ b/src/app/(portal)/access/page.tsx
@@ -8,6 +8,7 @@ import { getGrantStatus } from '@/components/access/access-constants'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { EmptyStateView } from '@/components/ui/empty-state'
 import type { AccessGrant } from '@/types/access'
+import type { GrantModalSubmitData } from '@/components/access/grant-modal'
 
 export default function AccessPage() {
   const { data, isLoading } = useAccessGrants()
@@ -20,18 +21,26 @@ export default function AccessPage() {
   const grants = useMemo(() => data?.items ?? [], [data])
 
   const activeGrants = useMemo(
-    () => grants.filter((g) => getGrantStatus(g.expiresAt).status !== 'expired'),
+    () =>
+      grants.filter((g) => {
+        const { status } = getGrantStatus(g.expiresAt, g.revoked)
+        return status !== 'expired' && status !== 'revoked'
+      }),
     [grants],
   )
 
-  const expiredGrants = useMemo(
-    () => grants.filter((g) => getGrantStatus(g.expiresAt).status === 'expired'),
+  const inactiveGrants = useMemo(
+    () =>
+      grants.filter((g) => {
+        const { status } = getGrantStatus(g.expiresAt, g.revoked)
+        return status === 'expired' || status === 'revoked'
+      }),
     [grants],
   )
 
   const handleRevokeClick = useCallback(
     (id: string) => {
-      const grant = grants.find((g) => g.id === id)
+      const grant = grants.find((g) => g.grantId === id)
       if (grant) setRevokeTarget(grant)
     },
     [grants],
@@ -39,21 +48,26 @@ export default function AccessPage() {
 
   const handleRevokeConfirm = useCallback(() => {
     if (!revokeTarget) return
-    revokeGrant.mutate(revokeTarget.id, {
+    revokeGrant.mutate(revokeTarget.grantId, {
       onSuccess: () => setRevokeTarget(null),
     })
   }, [revokeTarget, revokeGrant])
 
   const handleGrantSubmit = useCallback(
-    (formData: {
-      doctorId: string
-      doctorName: string
-      reportIds: string[]
-      expiresAt: string
-    }) => {
-      createGrant.mutate(formData, {
-        onSuccess: () => setModalOpen(false),
-      })
+    (formData: GrantModalSubmitData) => {
+      createGrant.mutate(
+        {
+          doctorSub: formData.doctorId,
+          doctorName: formData.doctorName,
+          allReports: formData.allReports,
+          reportIds: formData.reportIds,
+          purpose: formData.purpose,
+          expiresAt: formData.expiresAt,
+        },
+        {
+          onSuccess: () => setModalOpen(false),
+        },
+      )
     },
     [createGrant],
   )
@@ -122,7 +136,7 @@ export default function AccessPage() {
           <VStack gap="3" align="stretch">
             {activeGrants.map((grant) => (
               <GrantCard
-                key={grant.id}
+                key={grant.grantId}
                 grant={grant}
                 onRevoke={handleRevokeClick}
               />
@@ -131,8 +145,8 @@ export default function AccessPage() {
         </Box>
       )}
 
-      {/* Expired grants */}
-      {!isLoading && expiredGrants.length > 0 && (
+      {/* Inactive grants (expired + revoked) */}
+      {!isLoading && inactiveGrants.length > 0 && (
         <Box>
           <Heading
             as="h2"
@@ -141,12 +155,12 @@ export default function AccessPage() {
             color="text.primary"
             mb="4"
           >
-            Expired Grants
+            Inactive Grants
           </Heading>
           <VStack gap="3" align="stretch">
-            {expiredGrants.map((grant) => (
+            {inactiveGrants.map((grant) => (
               <GrantCard
-                key={grant.id}
+                key={grant.grantId}
                 grant={grant}
                 onRevoke={handleRevokeClick}
               />

--- a/src/components/access/access-constants.test.ts
+++ b/src/components/access/access-constants.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   getGrantStatus,
+  deriveAccessGrantStatus,
   formatExpiryText,
   getInitials,
 } from './access-constants'
@@ -45,6 +46,44 @@ describe('getGrantStatus', () => {
     const future = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString()
     const result = getGrantStatus(future)
     expect(result.status).toBe('active')
+  })
+
+  it('returns revoked status when revoked is true', () => {
+    const future = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString()
+    const result = getGrantStatus(future, true)
+    expect(result.status).toBe('revoked')
+    expect(result.label).toBe('Revoked')
+    expect(result.badgeVariant).toBe('error')
+    expect(result.daysRemaining).toBe(0)
+  })
+
+  it('returns revoked even when grant would otherwise be active', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+    const result = getGrantStatus(future, true)
+    expect(result.status).toBe('revoked')
+  })
+
+  it('returns revoked even when grant is expired', () => {
+    const past = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const result = getGrantStatus(past, true)
+    expect(result.status).toBe('revoked')
+  })
+})
+
+describe('deriveAccessGrantStatus', () => {
+  it('returns revoked when revoked is true', () => {
+    const future = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString()
+    expect(deriveAccessGrantStatus(future, true)).toBe('revoked')
+  })
+
+  it('returns active for non-expired non-revoked grant', () => {
+    const future = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString()
+    expect(deriveAccessGrantStatus(future, false)).toBe('active')
+  })
+
+  it('returns expired for past non-revoked grant', () => {
+    const past = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
+    expect(deriveAccessGrantStatus(past, false)).toBe('expired')
   })
 })
 

--- a/src/components/access/access-constants.ts
+++ b/src/components/access/access-constants.ts
@@ -1,15 +1,25 @@
 import type { StatusBadgeProps } from '@/components/ui/status-badge'
+import type { AccessGrantStatus } from '@/types/access'
 
-export type GrantStatus = 'active' | 'expiring' | 'expired'
+export type GrantDisplayStatus = 'active' | 'expiring' | 'expired' | 'revoked'
 
 interface GrantStatusInfo {
-  status: GrantStatus
+  status: GrantDisplayStatus
   label: string
   badgeVariant: StatusBadgeProps['variant']
   daysRemaining: number
 }
 
-export function getGrantStatus(expiresAt: string): GrantStatusInfo {
+export function getGrantStatus(expiresAt: string, revoked = false): GrantStatusInfo {
+  if (revoked) {
+    return {
+      status: 'revoked',
+      label: 'Revoked',
+      badgeVariant: 'error',
+      daysRemaining: 0,
+    }
+  }
+
   const now = new Date()
   const expiry = new Date(expiresAt)
   const diffMs = expiry.getTime() - now.getTime()
@@ -39,6 +49,13 @@ export function getGrantStatus(expiresAt: string): GrantStatusInfo {
     badgeVariant: 'success',
     daysRemaining,
   }
+}
+
+export function deriveAccessGrantStatus(expiresAt: string, revoked: boolean): AccessGrantStatus {
+  if (revoked) return 'revoked'
+  const now = new Date()
+  const expiry = new Date(expiresAt)
+  return expiry.getTime() <= now.getTime() ? 'expired' : 'active'
 }
 
 export function formatExpiryText(daysRemaining: number): string {

--- a/src/components/access/grant-card.test.tsx
+++ b/src/components/access/grant-card.test.tsx
@@ -5,11 +5,16 @@ import type { AccessGrant } from '@/types/access'
 
 function makeGrant(overrides: Partial<AccessGrant> = {}): AccessGrant {
   return {
-    id: 'g1',
-    doctorId: 'd1',
+    grantId: 'g1',
+    patientSub: 'p1',
+    doctorSub: 'd1',
     doctorName: 'Dr. Priya Sharma',
+    allReports: false,
     reportIds: ['r1', 'r2', 'r3'],
+    purpose: 'Follow-up consultation',
+    startsAt: '2025-01-01T00:00:00Z',
     expiresAt: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+    revoked: false,
     createdAt: '2025-01-01T00:00:00Z',
     ...overrides,
   }
@@ -22,7 +27,7 @@ describe('GrantCard', () => {
     expect(screen.getByText('DP')).toBeInTheDocument()
   })
 
-  it('shows report count', () => {
+  it('shows report count for specific reports', () => {
     render(<GrantCard grant={makeGrant()} onRevoke={vi.fn()} />)
     expect(screen.getByText('3 reports shared')).toBeInTheDocument()
   })
@@ -32,6 +37,16 @@ describe('GrantCard', () => {
       <GrantCard grant={makeGrant({ reportIds: ['r1'] })} onRevoke={vi.fn()} />,
     )
     expect(screen.getByText('1 report shared')).toBeInTheDocument()
+  })
+
+  it('shows "All reports" when allReports is true', () => {
+    render(
+      <GrantCard
+        grant={makeGrant({ allReports: true, reportIds: [] })}
+        onRevoke={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('All reports')).toBeInTheDocument()
   })
 
   it('shows Active badge for non-expiring grants', () => {
@@ -55,6 +70,12 @@ describe('GrantCard', () => {
     expect(screen.getByText('Expired')).toBeInTheDocument()
   })
 
+  it('shows Revoked badge for revoked grants', () => {
+    const revoked = makeGrant({ revoked: true })
+    render(<GrantCard grant={revoked} onRevoke={vi.fn()} />)
+    expect(screen.getByText('Revoked')).toBeInTheDocument()
+  })
+
   it('shows revoke button for active grants', () => {
     render(<GrantCard grant={makeGrant()} onRevoke={vi.fn()} />)
     expect(
@@ -70,7 +91,13 @@ describe('GrantCard', () => {
     expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument()
   })
 
-  it('calls onRevoke with grant id when revoke is clicked', async () => {
+  it('hides revoke button for revoked grants', () => {
+    const revoked = makeGrant({ revoked: true })
+    render(<GrantCard grant={revoked} onRevoke={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument()
+  })
+
+  it('calls onRevoke with grantId when revoke is clicked', async () => {
     const onRevoke = vi.fn()
     const { userEvent } = await import('@/test/render')
     render(<GrantCard grant={makeGrant()} onRevoke={onRevoke} />)
@@ -78,5 +105,31 @@ describe('GrantCard', () => {
       screen.getByRole('button', { name: /revoke access for dr\. priya sharma/i }),
     )
     expect(onRevoke).toHaveBeenCalledWith('g1')
+  })
+
+  it('displays purpose text when present', () => {
+    render(<GrantCard grant={makeGrant({ purpose: 'Blood test review' })} onRevoke={vi.fn()} />)
+    expect(screen.getByTestId('grant-purpose')).toHaveTextContent('Blood test review')
+  })
+
+  it('does not display purpose when empty', () => {
+    render(<GrantCard grant={makeGrant({ purpose: '' })} onRevoke={vi.fn()} />)
+    expect(screen.queryByTestId('grant-purpose')).not.toBeInTheDocument()
+  })
+
+  it('shows reduced opacity for revoked grants', () => {
+    const revoked = makeGrant({ revoked: true })
+    render(<GrantCard grant={revoked} onRevoke={vi.fn()} />)
+    const card = screen.getByTestId('grant-card')
+    expect(card).toHaveStyle({ opacity: '0.6' })
+  })
+
+  it('shows reduced opacity for expired grants', () => {
+    const expired = makeGrant({
+      expiresAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    })
+    render(<GrantCard grant={expired} onRevoke={vi.fn()} />)
+    const card = screen.getByTestId('grant-card')
+    expect(card).toHaveStyle({ opacity: '0.6' })
   })
 })

--- a/src/components/access/grant-card.tsx
+++ b/src/components/access/grant-card.tsx
@@ -17,11 +17,16 @@ export interface GrantCardProps {
 export function GrantCard({ grant, onRevoke }: GrantCardProps) {
   const { label, badgeVariant, daysRemaining, status } = getGrantStatus(
     grant.expiresAt,
+    grant.revoked,
   )
-  const isExpired = status === 'expired'
+  const isInactive = status === 'expired' || status === 'revoked'
   const initials = getInitials(grant.doctorName)
-  const expiryText = formatExpiryText(daysRemaining)
+  const expiryText = status === 'revoked' ? '' : formatExpiryText(daysRemaining)
   const isExpiryWarning = status === 'expiring'
+
+  const reportSummary = grant.allReports
+    ? 'All reports'
+    : `${grant.reportIds.length} report${grant.reportIds.length === 1 ? '' : 's'} shared`
 
   return (
     <Box
@@ -34,7 +39,7 @@ export function GrantCard({ grant, onRevoke }: GrantCardProps) {
       boxShadow="glass"
       transition="transform 0.2s, box-shadow 0.2s"
       _hover={{ transform: 'translateY(-1px)', boxShadow: 'md' }}
-      opacity={isExpired ? 0.6 : 1}
+      opacity={isInactive ? 0.6 : 1}
       data-testid="grant-card"
     >
       <Flex align="center" gap="4" flexWrap={{ base: 'wrap', md: 'nowrap' }}>
@@ -48,8 +53,8 @@ export function GrantCard({ grant, onRevoke }: GrantCardProps) {
           fontFamily="mono"
           fontSize="0.85rem"
           fontWeight="medium"
-          bg={isExpired ? 'border.default' : 'action.primary'}
-          color={isExpired ? 'text.muted' : 'action.primary.text'}
+          bg={isInactive ? 'border.default' : 'action.primary'}
+          color={isInactive ? 'text.muted' : 'action.primary.text'}
         >
           {initials}
         </Flex>
@@ -64,17 +69,31 @@ export function GrantCard({ grant, onRevoke }: GrantCardProps) {
               fontFamily="mono"
               fontSize="0.78rem"
               color="text.secondary"
+              data-testid="report-summary"
             >
-              {grant.reportIds.length} report{grant.reportIds.length === 1 ? '' : 's'} shared
+              {reportSummary}
             </Text>
-            <Text
-              fontFamily="mono"
-              fontSize="0.78rem"
-              color={isExpiryWarning ? 'amber.400' : 'text.muted'}
-            >
-              {expiryText}
-            </Text>
+            {expiryText && (
+              <Text
+                fontFamily="mono"
+                fontSize="0.78rem"
+                color={isExpiryWarning ? 'amber.400' : 'text.muted'}
+              >
+                {expiryText}
+              </Text>
+            )}
           </Flex>
+          {grant.purpose && (
+            <Text
+              fontSize="0.82rem"
+              color="text.muted"
+              mt="1"
+              lineClamp={1}
+              data-testid="grant-purpose"
+            >
+              {grant.purpose}
+            </Text>
+          )}
         </Box>
 
         {/* Actions */}
@@ -87,7 +106,7 @@ export function GrantCard({ grant, onRevoke }: GrantCardProps) {
           mt={{ base: '1', md: '0' }}
         >
           <StatusBadge variant={badgeVariant}>{label}</StatusBadge>
-          {!isExpired && (
+          {!isInactive && (
             <Button
               variant="outline"
               size="sm"
@@ -95,7 +114,7 @@ export function GrantCard({ grant, onRevoke }: GrantCardProps) {
               borderColor="coral.400"
               color="coral.400"
               _hover={{ bg: 'rgba(255, 107, 107, 0.08)' }}
-              onClick={() => onRevoke(grant.id)}
+              onClick={() => onRevoke(grant.grantId)}
               aria-label={`Revoke access for ${grant.doctorName}`}
             >
               Revoke

--- a/src/components/access/grant-modal.test.tsx
+++ b/src/components/access/grant-modal.test.tsx
@@ -74,6 +74,21 @@ beforeEach(() => {
   })
 })
 
+async function selectDoctor() {
+  await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+  await waitFor(() => {
+    expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
+  })
+  await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+}
+
+async function selectReport() {
+  await waitFor(() => {
+    expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
+  })
+  await userEvent.click(screen.getAllByTestId('report-checkbox')[0])
+}
+
 describe('GrantModal', () => {
   it('renders modal title and subtitle when open', () => {
     render(
@@ -113,27 +128,43 @@ describe('GrantModal', () => {
     expect(screen.getAllByTestId('doctor-search-result')).toHaveLength(2)
   })
 
-  it('shows report selection after selecting a doctor', async () => {
+  it('shows report selection and all-reports toggle after selecting a doctor', async () => {
     render(
       <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
     )
 
-    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
+    await selectDoctor()
 
-    await waitFor(() => {
-      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
-    })
-
-    // Select the doctor
-    const selectButtons = screen.getAllByRole('button', { name: 'Select' })
-    await userEvent.click(selectButtons[0])
-
-    // Should show report selection
+    // Should show report selection with all-reports toggle
     await waitFor(() => {
       expect(screen.getByText(/step 2/i)).toBeInTheDocument()
     })
+    expect(screen.getByText('Grant access to all reports')).toBeInTheDocument()
     expect(screen.getByText('Complete Blood Count')).toBeInTheDocument()
     expect(screen.getByText('Chest X-Ray')).toBeInTheDocument()
+  })
+
+  it('hides individual report list when all-reports is toggled on', async () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+
+    await selectDoctor()
+
+    await waitFor(() => {
+      expect(screen.getByText('Grant access to all reports')).toBeInTheDocument()
+    })
+
+    // Toggle all reports on
+    await userEvent.click(screen.getByLabelText('Grant access to all reports'))
+
+    // Individual report checkboxes should be hidden
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('report-checkbox')).toHaveLength(0)
+    })
+
+    // Duration step should now appear
+    expect(screen.getByText(/step 3/i)).toBeInTheDocument()
   })
 
   it('shows duration picker after selecting reports', async () => {
@@ -141,18 +172,8 @@ describe('GrantModal', () => {
       <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
     )
 
-    // Search and select doctor
-    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
-    await waitFor(() => {
-      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
-    })
-    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
-
-    // Select a report
-    await waitFor(() => {
-      expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
-    })
-    await userEvent.click(screen.getAllByTestId('report-checkbox')[0])
+    await selectDoctor()
+    await selectReport()
 
     // Duration picker should appear
     await waitFor(() => {
@@ -163,40 +184,49 @@ describe('GrantModal', () => {
     expect(screen.getByRole('button', { name: '90 days' })).toBeInTheDocument()
   })
 
+  it('shows purpose field in step 3', async () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+
+    await selectDoctor()
+    await selectReport()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Purpose of access')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Purpose of access')).toBeInTheDocument()
+    expect(screen.getByText('0/500')).toBeInTheDocument()
+  })
+
   it('shows Change button after selecting a doctor', async () => {
     render(
       <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
     )
 
-    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
-    await waitFor(() => {
-      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
-    })
-    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+    await selectDoctor()
 
     expect(screen.getByRole('button', { name: /change doctor/i })).toBeInTheDocument()
   })
 
-  it('calls onSubmit with correct data on form completion', async () => {
+  it('calls onSubmit with correct data including new fields on form completion', async () => {
     const onSubmit = vi.fn()
     render(
       <GrantModal open onClose={vi.fn()} onSubmit={onSubmit} />,
     )
 
     // Step 1: Select doctor
-    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
-    await waitFor(() => {
-      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
-    })
-    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+    await selectDoctor()
 
     // Step 2: Select report
-    await waitFor(() => {
-      expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
-    })
-    await userEvent.click(screen.getAllByTestId('report-checkbox')[0])
+    await selectReport()
 
-    // Step 3: Duration (30 days is default)
+    // Step 3: Fill purpose and duration (30 days default)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Purpose of access')).toBeInTheDocument()
+    })
+    await userEvent.type(screen.getByLabelText('Purpose of access'), 'Follow-up consultation')
+
     // Submit
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /grant access$/i })).toBeInTheDocument()
@@ -207,10 +237,59 @@ describe('GrantModal', () => {
       expect.objectContaining({
         doctorId: 'doc1',
         doctorName: 'Dr. Arun Mehta',
+        allReports: false,
         reportIds: ['r1'],
+        purpose: 'Follow-up consultation',
         expiresAt: expect.any(String),
       }),
     )
+  })
+
+  it('calls onSubmit with allReports true and empty reportIds', async () => {
+    const onSubmit = vi.fn()
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={onSubmit} />,
+    )
+
+    await selectDoctor()
+
+    // Toggle all reports
+    await waitFor(() => {
+      expect(screen.getByText('Grant access to all reports')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByLabelText('Grant access to all reports'))
+
+    // Fill purpose
+    await waitFor(() => {
+      expect(screen.getByLabelText('Purpose of access')).toBeInTheDocument()
+    })
+    await userEvent.type(screen.getByLabelText('Purpose of access'), 'Ongoing care')
+
+    // Submit
+    await userEvent.click(screen.getByRole('button', { name: /grant access$/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allReports: true,
+        reportIds: [],
+        purpose: 'Ongoing care',
+      }),
+    )
+  })
+
+  it('disables submit when purpose is empty', async () => {
+    render(
+      <GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    )
+
+    await selectDoctor()
+    await selectReport()
+
+    // Do not fill purpose -- submit should be disabled
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /grant access$/i })).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /grant access$/i })).toBeDisabled()
   })
 
   it('does not render modal content when closed', () => {
@@ -233,11 +312,7 @@ describe('GrantModal', () => {
 
     render(<GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />)
 
-    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
-    await waitFor(() => {
-      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
-    })
-    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+    await selectDoctor()
 
     await waitFor(() => {
       expect(screen.getByText('No reports available to share.')).toBeInTheDocument()
@@ -248,23 +323,16 @@ describe('GrantModal', () => {
     const onSubmit = vi.fn()
     render(<GrantModal open onClose={vi.fn()} onSubmit={onSubmit} />)
 
-    // Step 1: Select doctor
-    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
-    await waitFor(() => {
-      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
-    })
-    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+    await selectDoctor()
+    await selectReport()
 
-    // Step 2: Select report
+    // Fill purpose
     await waitFor(() => {
-      expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
+      expect(screen.getByLabelText('Purpose of access')).toBeInTheDocument()
     })
-    await userEvent.click(screen.getAllByTestId('report-checkbox')[0])
+    await userEvent.type(screen.getByLabelText('Purpose of access'), 'Review')
 
-    // Step 3: Enter custom duration
-    await waitFor(() => {
-      expect(screen.getByLabelText('Custom duration in days')).toBeInTheDocument()
-    })
+    // Enter custom duration
     await userEvent.type(screen.getByLabelText('Custom duration in days'), '45')
 
     // Submit
@@ -273,6 +341,8 @@ describe('GrantModal', () => {
       expect.objectContaining({
         doctorId: 'doc1',
         reportIds: ['r1'],
+        allReports: false,
+        purpose: 'Review',
       }),
     )
   })
@@ -280,20 +350,10 @@ describe('GrantModal', () => {
   it('allows selecting a different duration preset', async () => {
     render(<GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />)
 
-    // Step 1: Select doctor
-    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
-    await waitFor(() => {
-      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
-    })
-    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+    await selectDoctor()
+    await selectReport()
 
-    // Step 2: Select report
-    await waitFor(() => {
-      expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
-    })
-    await userEvent.click(screen.getAllByTestId('report-checkbox')[0])
-
-    // Step 3: Click 7 days
+    // Click 7 days
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '7 days' })).toBeInTheDocument()
     })
@@ -306,14 +366,9 @@ describe('GrantModal', () => {
   it('can deselect a report to remove it', async () => {
     render(<GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />)
 
-    // Step 1: Select doctor
-    await userEvent.type(screen.getByPlaceholderText('Search by name or ID...'), 'Dr. Ar')
-    await waitFor(() => {
-      expect(screen.getByText('Dr. Arun Mehta')).toBeInTheDocument()
-    })
-    await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
+    await selectDoctor()
 
-    // Step 2: Select then deselect a report
+    // Select then deselect a report
     await waitFor(() => {
       expect(screen.getAllByTestId('report-checkbox')).toHaveLength(2)
     })
@@ -347,5 +402,19 @@ describe('GrantModal', () => {
     // Select doctor
     await userEvent.click(screen.getAllByRole('button', { name: 'Select' })[0])
     expect(screen.getByRole('button', { name: /change doctor/i })).toBeInTheDocument()
+  })
+
+  it('updates purpose character counter as user types', async () => {
+    render(<GrantModal open onClose={vi.fn()} onSubmit={vi.fn()} />)
+
+    await selectDoctor()
+    await selectReport()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Purpose of access')).toBeInTheDocument()
+    })
+
+    await userEvent.type(screen.getByLabelText('Purpose of access'), 'Test')
+    expect(screen.getByText('4/500')).toBeInTheDocument()
   })
 })

--- a/src/components/access/grant-modal.tsx
+++ b/src/components/access/grant-modal.tsx
@@ -14,22 +14,28 @@ import {
   Flex,
   Input,
   Skeleton,
+  Switch,
   Text,
+  Textarea,
 } from '@chakra-ui/react'
 import { useSearchDoctors } from '@/hooks/access'
 import { useReports } from '@/hooks/reports'
 import { DURATION_OPTIONS, getInitials } from './access-constants'
 import type { Doctor } from '@/types/access'
 
+export interface GrantModalSubmitData {
+  doctorId: string
+  doctorName: string
+  allReports: boolean
+  reportIds: string[]
+  purpose: string
+  expiresAt: string
+}
+
 export interface GrantModalProps {
   open: boolean
   onClose: () => void
-  onSubmit: (data: {
-    doctorId: string
-    doctorName: string
-    reportIds: string[]
-    expiresAt: string
-  }) => void
+  onSubmit: (data: GrantModalSubmitData) => void
   loading?: boolean
 }
 
@@ -38,24 +44,28 @@ type Step = 'search' | 'reports' | 'duration'
 export function GrantModal({ open, onClose, onSubmit, loading = false }: GrantModalProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedDoctor, setSelectedDoctor] = useState<Doctor | null>(null)
+  const [allReports, setAllReports] = useState(false)
   const [selectedReportIds, setSelectedReportIds] = useState<Set<string>>(new Set())
   const [selectedDuration, setSelectedDuration] = useState<number | null>(30)
   const [customDays, setCustomDays] = useState('')
+  const [purpose, setPurpose] = useState('')
 
   const doctorSearch = useSearchDoctors(searchQuery)
   const { data: reportsData, isLoading: reportsLoading } = useReports({ pageSize: 100 })
 
+  const hasReportSelection = allReports || selectedReportIds.size > 0
   const currentStep: Step = !selectedDoctor
     ? 'search'
-    : selectedReportIds.size === 0
+    : !hasReportSelection
       ? 'reports'
       : 'duration'
 
   const effectiveDays = selectedDuration ?? (customDays ? parseInt(customDays, 10) : 0)
   const canSubmit =
     selectedDoctor !== null &&
-    selectedReportIds.size > 0 &&
+    hasReportSelection &&
     effectiveDays > 0 &&
+    purpose.trim().length > 0 &&
     !loading
 
   const handleSelectDoctor = useCallback((doctor: Doctor) => {
@@ -71,6 +81,15 @@ export function GrantModal({ open, onClose, onSubmit, loading = false }: GrantMo
         next.add(reportId)
       }
       return next
+    })
+  }, [])
+
+  const handleAllReportsToggle = useCallback(() => {
+    setAllReports((prev) => {
+      if (!prev) {
+        setSelectedReportIds(new Set())
+      }
+      return !prev
     })
   }, [])
 
@@ -92,17 +111,21 @@ export function GrantModal({ open, onClose, onSubmit, loading = false }: GrantMo
     onSubmit({
       doctorId: selectedDoctor.id,
       doctorName: selectedDoctor.name,
-      reportIds: Array.from(selectedReportIds),
+      allReports,
+      reportIds: allReports ? [] : Array.from(selectedReportIds),
+      purpose: purpose.trim(),
       expiresAt,
     })
-  }, [selectedDoctor, selectedReportIds, effectiveDays, canSubmit, onSubmit])
+  }, [selectedDoctor, selectedReportIds, allReports, purpose, effectiveDays, canSubmit, onSubmit])
 
   const handleClose = useCallback(() => {
     setSearchQuery('')
     setSelectedDoctor(null)
+    setAllReports(false)
     setSelectedReportIds(new Set())
     setSelectedDuration(30)
     setCustomDays('')
+    setPurpose('')
     onClose()
   }, [onClose])
 
@@ -167,23 +190,81 @@ export function GrantModal({ open, onClose, onSubmit, loading = false }: GrantMo
                   label="Select Reports"
                   active={currentStep === 'reports'}
                 />
-                <ReportSelector
-                  reports={reports}
-                  selectedIds={selectedReportIds}
-                  onToggle={toggleReport}
-                  loading={reportsLoading}
-                />
+
+                {/* All Reports Toggle */}
+                <Flex
+                  align="center"
+                  justify="space-between"
+                  px="3"
+                  py="2.5"
+                  mb="3"
+                  borderWidth="1px"
+                  borderColor={allReports ? 'action.primary' : 'border.subtle'}
+                  borderRadius="lg"
+                  bg="bg.overlay"
+                >
+                  <Box>
+                    <Text fontSize="0.88rem" color="text.primary" fontWeight="medium">
+                      Grant access to all reports
+                    </Text>
+                    <Text fontSize="0.78rem" color="text.muted">
+                      Includes current and future reports
+                    </Text>
+                  </Box>
+                  <Switch.Root
+                    checked={allReports}
+                    onCheckedChange={handleAllReportsToggle}
+                    aria-label="Grant access to all reports"
+                  >
+                    <Switch.HiddenInput />
+                    <Switch.Control>
+                      <Switch.Thumb />
+                    </Switch.Control>
+                  </Switch.Root>
+                </Flex>
+
+                {!allReports && (
+                  <ReportSelector
+                    reports={reports}
+                    selectedIds={selectedReportIds}
+                    onToggle={toggleReport}
+                    loading={reportsLoading}
+                  />
+                )}
               </Box>
             )}
 
-            {/* Step 3: Set Duration */}
-            {selectedDoctor && selectedReportIds.size > 0 && (
+            {/* Step 3: Purpose & Duration */}
+            {selectedDoctor && hasReportSelection && (
               <Box role="group" aria-label="Step 3: Set Duration">
                 <StepLabel
                   step={3}
-                  label="Set Duration"
+                  label="Purpose & Duration"
                   active={currentStep === 'duration'}
                 />
+
+                {/* Purpose field */}
+                <Box mb="4">
+                  <Text fontSize="0.82rem" color="text.secondary" mb="1.5" fontWeight="medium">
+                    Purpose of access
+                  </Text>
+                  <Textarea
+                    placeholder="e.g., Follow-up consultation for blood work review"
+                    value={purpose}
+                    onChange={(e) => setPurpose(e.target.value)}
+                    bg="bg.glass"
+                    borderColor="border.default"
+                    borderRadius="lg"
+                    fontSize="0.88rem"
+                    rows={2}
+                    maxLength={500}
+                    aria-label="Purpose of access"
+                  />
+                  <Text fontSize="0.72rem" color="text.muted" mt="1" textAlign="right">
+                    {purpose.length}/500
+                  </Text>
+                </Box>
+
                 <DurationPicker
                   selected={selectedDuration}
                   customDays={customDays}
@@ -194,7 +275,7 @@ export function GrantModal({ open, onClose, onSubmit, loading = false }: GrantMo
             )}
 
             {/* Submit */}
-            {selectedDoctor && selectedReportIds.size > 0 && (
+            {selectedDoctor && hasReportSelection && (
               <Button
                 w="full"
                 borderRadius="full"
@@ -232,7 +313,7 @@ export function GrantModal({ open, onClose, onSubmit, loading = false }: GrantMo
   )
 }
 
-/* ── Sub-components ── */
+/* -- Sub-components -- */
 
 function StepLabel({ step, label, active }: { step: number; label: string; active: boolean }) {
   return (

--- a/src/components/access/index.ts
+++ b/src/components/access/index.ts
@@ -1,4 +1,4 @@
 export { AccessPageHeader } from './access-page-header'
 export { GrantCard } from './grant-card'
 export { GrantModal } from './grant-modal'
-export { getGrantStatus, formatExpiryText, getInitials } from './access-constants'
+export { getGrantStatus, deriveAccessGrantStatus, formatExpiryText, getInitials } from './access-constants'

--- a/src/hooks/access/use-access-grants.test.tsx
+++ b/src/hooks/access/use-access-grants.test.tsx
@@ -36,11 +36,16 @@ describe('useAccessGrants', () => {
     const data = {
       items: [
         {
-          id: 'ag1',
-          doctorId: 'd1',
+          grantId: 'ag1',
+          patientSub: 'p1',
+          doctorSub: 'd1',
           doctorName: 'Dr. Smith',
+          allReports: false,
           reportIds: ['r1'],
+          purpose: 'Follow-up',
+          startsAt: '2025-01-01T00:00:00Z',
           expiresAt: '2025-06-01T00:00:00Z',
+          revoked: false,
           createdAt: '2025-01-01T00:00:00Z',
         },
       ],

--- a/src/hooks/access/use-create-grant.test.tsx
+++ b/src/hooks/access/use-create-grant.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { clearEtagCache } from '@/lib/api/client'
 import { queryKeys } from '@/lib/api/query-keys'
 import { useCreateGrant } from './use-create-grant'
-import type { AccessGrantListResponse } from '@/types/access'
+import type { AccessGrantListResponse, CreateAccessGrantRequest } from '@/types/access'
 
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
@@ -33,10 +33,12 @@ function createWrapper(gcTime = 0) {
   }
 }
 
-const grantRequest = {
-  doctorId: 'd1',
+const grantRequest: CreateAccessGrantRequest = {
+  doctorSub: 'd1',
   doctorName: 'Dr. Smith',
+  allReports: false,
   reportIds: ['r1', 'r2'],
+  purpose: 'Follow-up consultation',
   expiresAt: '2025-06-01T00:00:00Z',
 }
 
@@ -48,8 +50,16 @@ beforeEach(() => {
 describe('useCreateGrant', () => {
   it('sends POST request with grant data', async () => {
     const created = {
-      id: 'ag1',
-      ...grantRequest,
+      grantId: 'ag1',
+      patientSub: 'p1',
+      doctorSub: grantRequest.doctorSub,
+      doctorName: grantRequest.doctorName,
+      allReports: grantRequest.allReports,
+      reportIds: grantRequest.reportIds,
+      purpose: grantRequest.purpose,
+      startsAt: '2025-01-15T10:00:00Z',
+      expiresAt: grantRequest.expiresAt,
+      revoked: false,
       createdAt: '2025-01-15T10:00:00Z',
     }
     mockFetch.mockResolvedValue(jsonResponse(created))
@@ -71,17 +81,56 @@ describe('useCreateGrant', () => {
     expect(JSON.parse(calledInit.body as string)).toEqual(grantRequest)
   })
 
+  it('sends POST request with allReports grant', async () => {
+    const allReportsRequest: CreateAccessGrantRequest = {
+      doctorSub: 'd1',
+      doctorName: 'Dr. Smith',
+      allReports: true,
+      reportIds: [],
+      purpose: 'Ongoing treatment',
+      expiresAt: '2025-06-01T00:00:00Z',
+    }
+    const created = {
+      grantId: 'ag2',
+      patientSub: 'p1',
+      doctorSub: allReportsRequest.doctorSub,
+      doctorName: allReportsRequest.doctorName,
+      allReports: true,
+      reportIds: [],
+      purpose: allReportsRequest.purpose,
+      startsAt: '2025-01-15T10:00:00Z',
+      expiresAt: allReportsRequest.expiresAt,
+      revoked: false,
+      createdAt: '2025-01-15T10:00:00Z',
+    }
+    mockFetch.mockResolvedValue(jsonResponse(created))
+
+    const { result } = renderHook(() => useCreateGrant(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(() => result.current.mutateAsync(allReportsRequest))
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.allReports).toBe(true)
+  })
+
   it('optimistically adds grant to list cache', async () => {
     const wrapper = createWrapper(Infinity)
 
     const initialData: AccessGrantListResponse = {
       items: [
         {
-          id: 'ag-existing',
-          doctorId: 'd2',
+          grantId: 'ag-existing',
+          patientSub: 'p1',
+          doctorSub: 'd2',
           doctorName: 'Dr. Jones',
+          allReports: false,
           reportIds: ['r3'],
+          purpose: 'Initial consultation',
+          startsAt: '2025-01-01T00:00:00Z',
           expiresAt: '2025-07-01T00:00:00Z',
+          revoked: false,
           createdAt: '2025-01-01T00:00:00Z',
         },
       ],
@@ -99,8 +148,11 @@ describe('useCreateGrant', () => {
         resolveCreate = () =>
           resolve(
             jsonResponse({
-              id: 'ag-new',
+              grantId: 'ag-new',
+              patientSub: 'p1',
               ...grantRequest,
+              startsAt: '2025-01-15T10:00:00Z',
+              revoked: false,
               createdAt: '2025-01-15T10:00:00Z',
             }),
           )
@@ -118,9 +170,60 @@ describe('useCreateGrant', () => {
         queryKeys.accessGrants.list(),
       )
       expect(cached?.items).toHaveLength(2)
-      expect(cached?.items[0].id).toMatch(/^optimistic-/)
+      expect(cached?.items[0].grantId).toMatch(/^optimistic-/)
       expect(cached?.items[0].doctorName).toBe('Dr. Smith')
+      expect(cached?.items[0].allReports).toBe(false)
+      expect(cached?.items[0].purpose).toBe('Follow-up consultation')
       expect(cached?.totalCount).toBe(2)
+    })
+
+    await act(async () => {
+      resolveCreate()
+    })
+  })
+
+  it('optimistic grant includes allReports flag', async () => {
+    const wrapper = createWrapper(Infinity)
+
+    const initialData: AccessGrantListResponse = {
+      items: [],
+      page: 1,
+      pageSize: 10,
+      totalCount: 0,
+      totalPages: 0,
+    }
+
+    queryClient.setQueryData(queryKeys.accessGrants.list(), initialData)
+
+    const allReportsRequest: CreateAccessGrantRequest = {
+      doctorSub: 'd1',
+      doctorName: 'Dr. Smith',
+      allReports: true,
+      reportIds: [],
+      purpose: 'Treatment plan',
+      expiresAt: '2025-06-01T00:00:00Z',
+    }
+
+    let resolveCreate!: () => void
+    mockFetch.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveCreate = () =>
+          resolve(jsonResponse({ grantId: 'ag-new', ...allReportsRequest }))
+      }),
+    )
+
+    const { result } = renderHook(() => useCreateGrant(), { wrapper })
+
+    await act(async () => {
+      result.current.mutate(allReportsRequest)
+    })
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<AccessGrantListResponse>(
+        queryKeys.accessGrants.list(),
+      )
+      expect(cached?.items[0].allReports).toBe(true)
+      expect(cached?.items[0].purpose).toBe('Treatment plan')
     })
 
     await act(async () => {
@@ -134,11 +237,16 @@ describe('useCreateGrant', () => {
     const initialData: AccessGrantListResponse = {
       items: [
         {
-          id: 'ag-existing',
-          doctorId: 'd2',
+          grantId: 'ag-existing',
+          patientSub: 'p1',
+          doctorSub: 'd2',
           doctorName: 'Dr. Jones',
+          allReports: false,
           reportIds: ['r3'],
+          purpose: 'Consultation',
+          startsAt: '2025-01-01T00:00:00Z',
           expiresAt: '2025-07-01T00:00:00Z',
+          revoked: false,
           createdAt: '2025-01-01T00:00:00Z',
         },
       ],
@@ -167,7 +275,7 @@ describe('useCreateGrant', () => {
         queryKeys.accessGrants.list(),
       )
       expect(cached?.items).toHaveLength(1)
-      expect(cached?.items[0].id).toBe('ag-existing')
+      expect(cached?.items[0].grantId).toBe('ag-existing')
       expect(cached?.totalCount).toBe(1)
     })
   })

--- a/src/hooks/access/use-create-grant.ts
+++ b/src/hooks/access/use-create-grant.ts
@@ -28,11 +28,16 @@ export function useCreateGrant() {
         (old) => {
           if (!old?.items) return old
           const optimisticGrant: AccessGrant = {
-            id: `optimistic-${Date.now()}`,
-            doctorId: request.doctorId,
+            grantId: `optimistic-${Date.now()}`,
+            patientSub: '',
+            doctorSub: request.doctorSub,
             doctorName: request.doctorName,
+            allReports: request.allReports,
             reportIds: request.reportIds,
+            purpose: request.purpose,
+            startsAt: new Date().toISOString(),
             expiresAt: request.expiresAt,
+            revoked: false,
             createdAt: new Date().toISOString(),
           }
           return {

--- a/src/hooks/access/use-revoke-grant.test.tsx
+++ b/src/hooks/access/use-revoke-grant.test.tsx
@@ -34,20 +34,30 @@ function createWrapper(gcTime = 0) {
 }
 
 const grantOne = {
-  id: 'ag1',
-  doctorId: 'd1',
+  grantId: 'ag1',
+  patientSub: 'p1',
+  doctorSub: 'd1',
   doctorName: 'Dr. Smith',
+  allReports: false,
   reportIds: ['r1'],
+  purpose: 'Consultation',
+  startsAt: '2025-01-01T00:00:00Z',
   expiresAt: '2025-06-01T00:00:00Z',
+  revoked: false,
   createdAt: '2025-01-01T00:00:00Z',
 }
 
 const grantTwo = {
-  id: 'ag2',
-  doctorId: 'd2',
+  grantId: 'ag2',
+  patientSub: 'p1',
+  doctorSub: 'd2',
   doctorName: 'Dr. Jones',
-  reportIds: ['r2'],
+  allReports: true,
+  reportIds: [],
+  purpose: 'Ongoing treatment',
+  startsAt: '2025-01-02T00:00:00Z',
   expiresAt: '2025-07-01T00:00:00Z',
+  revoked: false,
   createdAt: '2025-01-02T00:00:00Z',
 }
 
@@ -74,7 +84,7 @@ describe('useRevokeGrant', () => {
     )
   })
 
-  it('optimistically removes grant from list cache', async () => {
+  it('optimistically marks grant as revoked in list cache', async () => {
     const wrapper = createWrapper(Infinity)
 
     const initialData: AccessGrantListResponse = {
@@ -105,9 +115,11 @@ describe('useRevokeGrant', () => {
       const cached = queryClient.getQueryData<AccessGrantListResponse>(
         queryKeys.accessGrants.list(),
       )
-      expect(cached?.items).toHaveLength(1)
-      expect(cached?.items[0].id).toBe('ag2')
-      expect(cached?.totalCount).toBe(1)
+      expect(cached?.items).toHaveLength(2)
+      expect(cached?.items[0].grantId).toBe('ag1')
+      expect(cached?.items[0].revoked).toBe(true)
+      expect(cached?.items[1].grantId).toBe('ag2')
+      expect(cached?.items[1].revoked).toBe(false)
     })
 
     await act(async () => {
@@ -145,7 +157,8 @@ describe('useRevokeGrant', () => {
         queryKeys.accessGrants.list(),
       )
       expect(cached?.items).toHaveLength(1)
-      expect(cached?.items[0].id).toBe('ag1')
+      expect(cached?.items[0].grantId).toBe('ag1')
+      expect(cached?.items[0].revoked).toBe(false)
     })
   })
 })

--- a/src/hooks/access/use-revoke-grant.ts
+++ b/src/hooks/access/use-revoke-grant.ts
@@ -22,8 +22,9 @@ export function useRevokeGrant() {
           if (!old?.items) return old
           return {
             ...old,
-            items: old.items.filter((g) => g.id !== id),
-            totalCount: old.totalCount - 1,
+            items: old.items.map((g) =>
+              g.grantId === id ? { ...g, revoked: true } : g,
+            ),
           }
         },
       )

--- a/src/lib/schemas/accessGrant.test.ts
+++ b/src/lib/schemas/accessGrant.test.ts
@@ -5,13 +5,24 @@ import { accessGrantSchema } from './accessGrant'
 const validData = {
   doctorId: '550e8400-e29b-41d4-a716-446655440000',
   doctorName: 'Dr. Sharma',
+  allReports: false,
   reportIds: ['550e8400-e29b-41d4-a716-446655440001'],
+  purpose: 'Follow-up consultation',
   expiresAt: new Date(Date.now() + 86_400_000), // tomorrow
 }
 
 describe('accessGrantSchema', () => {
-  it('accepts valid access grant', () => {
+  it('accepts valid access grant with specific reports', () => {
     expect(accessGrantSchema.safeParse(validData).success).toBe(true)
+  })
+
+  it('accepts valid access grant with allReports', () => {
+    const result = accessGrantSchema.safeParse({
+      ...validData,
+      allReports: true,
+      reportIds: [],
+    })
+    expect(result.success).toBe(true)
   })
 
   it('accepts multiple report IDs', () => {
@@ -25,12 +36,22 @@ describe('accessGrantSchema', () => {
     expect(result.success).toBe(true)
   })
 
-  it('rejects empty reportIds array', () => {
+  it('rejects empty reportIds when allReports is false', () => {
     const result = accessGrantSchema.safeParse({
       ...validData,
+      allReports: false,
       reportIds: [],
     })
     expect(result.success).toBe(false)
+  })
+
+  it('accepts empty reportIds when allReports is true', () => {
+    const result = accessGrantSchema.safeParse({
+      ...validData,
+      allReports: true,
+      reportIds: [],
+    })
+    expect(result.success).toBe(true)
   })
 
   it('rejects invalid UUID for doctorId', () => {
@@ -62,6 +83,36 @@ describe('accessGrantSchema', () => {
       ...validData,
       doctorName: '',
     })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty purpose', () => {
+    const result = accessGrantSchema.safeParse({
+      ...validData,
+      purpose: '',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects purpose over 500 characters', () => {
+    const result = accessGrantSchema.safeParse({
+      ...validData,
+      purpose: 'a'.repeat(501),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts purpose at exactly 500 characters', () => {
+    const result = accessGrantSchema.safeParse({
+      ...validData,
+      purpose: 'a'.repeat(500),
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing allReports field', () => {
+    const { allReports: _, ...withoutAllReports } = validData
+    const result = accessGrantSchema.safeParse(withoutAllReports)
     expect(result.success).toBe(false)
   })
 })

--- a/src/lib/schemas/accessGrant.ts
+++ b/src/lib/schemas/accessGrant.ts
@@ -2,11 +2,21 @@ import { z } from 'zod/v4'
 
 import { futureDate, nonEmptyString } from './validators'
 
-export const accessGrantSchema = z.object({
-  doctorId: z.guid('Must be a valid UUID'),
-  doctorName: nonEmptyString,
-  reportIds: z.array(z.guid()).min(1, 'Select at least one report'),
-  expiresAt: futureDate,
-})
+export const accessGrantSchema = z
+  .object({
+    doctorId: z.guid('Must be a valid UUID'),
+    doctorName: nonEmptyString,
+    allReports: z.boolean(),
+    reportIds: z.array(z.guid()),
+    purpose: nonEmptyString.max(500, 'Purpose must be 500 characters or less'),
+    expiresAt: futureDate,
+  })
+  .refine(
+    (data) => data.allReports || data.reportIds.length > 0,
+    {
+      message: 'Select at least one report or grant access to all reports',
+      path: ['reportIds'],
+    },
+  )
 
 export type AccessGrant = z.infer<typeof accessGrantSchema>

--- a/src/types/access.ts
+++ b/src/types/access.ts
@@ -1,3 +1,5 @@
+export type AccessGrantStatus = 'active' | 'revoked' | 'expired'
+
 export interface Doctor {
   id: string
   name: string
@@ -10,11 +12,16 @@ export interface DoctorSearchResult {
 }
 
 export interface AccessGrant {
-  id: string
-  doctorId: string
+  grantId: string
+  patientSub: string
+  doctorSub: string
   doctorName: string
+  allReports: boolean
   reportIds: string[]
+  purpose: string
+  startsAt: string
   expiresAt: string
+  revoked: boolean
   createdAt: string
 }
 
@@ -27,8 +34,10 @@ export interface AccessGrantListResponse {
 }
 
 export interface CreateAccessGrantRequest {
-  doctorId: string
+  doctorSub: string
   doctorName: string
+  allReports: boolean
   reportIds: string[]
+  purpose: string
   expiresAt: string
 }


### PR DESCRIPTION
## Summary

- **Align `AccessGrant` interface** with backend `AccessGrantResponse`: rename `id` to `grantId`, `doctorId` to `doctorSub`, add `patientSub`, `allReports`, `purpose`, `startsAt`, and `revoked` fields
- **Align `CreateAccessGrantRequest`** with backend contract: add `allReports` boolean, `purpose` string, rename `doctorId` to `doctorSub`
- **Add `revoked` status handling** throughout UI: grant cards display Revoked badge (error variant), access page groups revoked + expired as "Inactive Grants", revoke hook optimistically marks grant as revoked instead of removing
- **Add `allReports` toggle** in grant modal (Switch component) -- hides individual report selection when enabled
- **Add required `purpose` field** in grant modal (Textarea, 500 char max) with character counter
- **Update Zod schema** with conditional validation: `allReports || reportIds.length > 0`, purpose max-length 500
- **Update all tests** for new field structure + add new tests for revoked status, allReports display, purpose field, toggle behavior

Closes #88

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (1056 tests, 0 failures)
- [x] All access-related tests pass (99 tests across 10 files)
- [x] 100% coverage on all modified source files
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)