### PR TITLE
feat(emergency-contacts): add delete confirmation to contact card

### DIFF
--- a/src/components/emergency/contact-card.test.tsx
+++ b/src/components/emergency/contact-card.test.tsx
@@ -45,10 +45,12 @@ describe('ContactCard', () => {
     expect(screen.getByText('Friend')).toBeInTheDocument()
   })
 
-  it('renders Edit and Remove buttons', () => {
+  it('renders Edit button and trash icon delete button', () => {
     render(<ContactCard contact={makeContact()} onEdit={vi.fn()} onDelete={vi.fn()} />)
     expect(screen.getByRole('button', { name: /edit priya sharma/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /remove priya sharma/i })).toBeInTheDocument()
+    const deleteBtn = screen.getByRole('button', { name: /remove priya sharma/i })
+    expect(deleteBtn).toBeInTheDocument()
+    expect(deleteBtn.querySelector('svg')).toBeInTheDocument()
   })
 
   it('calls onEdit with contact id when Edit is clicked', async () => {

--- a/src/components/emergency/contact-card.tsx
+++ b/src/components/emergency/contact-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Box, Button, Flex, Text } from '@chakra-ui/react'
+import { Box, Button, Flex, IconButton, Text } from '@chakra-ui/react'
 import { RELATIONSHIP_LABELS, getInitials, formatPhone } from './emergency-constants'
 import type { EmergencyContact } from '@/types/emergency'
 
@@ -102,7 +102,7 @@ export function ContactCard({ contact, onEdit, onDelete }: ContactCardProps) {
           >
             Edit
           </Button>
-          <Button
+          <IconButton
             variant="outline"
             size="sm"
             borderRadius="full"
@@ -112,8 +112,22 @@ export function ContactCard({ contact, onEdit, onDelete }: ContactCardProps) {
             onClick={() => onDelete(contact.id)}
             aria-label={`Remove ${contact.name}`}
           >
-            Remove
-          </Button>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+              <line x1="10" y1="11" x2="10" y2="17" />
+              <line x1="14" y1="11" x2="14" y2="17" />
+            </svg>
+          </IconButton>
         </Flex>
       </Flex>
     </Box>


### PR DESCRIPTION
## Summary
- Replaced the text "Remove" button on emergency contact cards with a compact trash icon button (`IconButton` with inline SVG) for a cleaner UI
- The `ConfirmDialog` confirmation flow, `useDeleteEmergencyContact` mutation with optimistic updates, and cache rollback on error were already implemented at the page level
- Updated contact card tests to verify the delete button renders with a trash icon SVG

Closes #92

## Test plan
- [ ] Verify trash icon button renders on each contact card
- [ ] Clicking the trash icon opens the "Remove Contact" confirmation dialog
- [ ] Confirming sends a DELETE request and optimistically removes the card
- [ ] Canceling dismisses the dialog without side effects
- [ ] All 1100 tests pass, coverage remains above 95.5%

Generated with [Claude Code](https://claude.com/claude-code)