### PR TITLE
fix(auth): remove duplicate /api prefix from token refresh URLs

### DIFF
--- a/src/lib/auth/refresh-token.test.ts
+++ b/src/lib/auth/refresh-token.test.ts
@@ -33,7 +33,7 @@ describe('refreshAccessToken', () => {
     const result = await refreshAccessToken(baseToken)
 
     expect(fetch).toHaveBeenCalledWith(
-      'https://api.example.com/api/auth/social/token/refresh',
+      'https://api.example.com/auth/social/token/refresh',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/lib/auth/refresh-token.ts
+++ b/src/lib/auth/refresh-token.ts
@@ -12,7 +12,7 @@ export async function refreshAccessToken(token: JWT): Promise<JWT> {
     throw new Error('Missing required environment variable: API_URL')
   }
 
-  const response = await fetch(`${apiUrl}/api/auth/social/token/refresh`, {
+  const response = await fetch(`${apiUrl}/auth/social/token/refresh`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ refreshToken: token.refreshToken }),

--- a/src/lib/auth/revoke-token.test.ts
+++ b/src/lib/auth/revoke-token.test.ts
@@ -16,14 +16,14 @@ afterEach(() => {
 })
 
 describe('revokeToken', () => {
-  it('calls POST /api/auth/social/token/revoke with refresh token', async () => {
+  it('calls POST /auth/social/token/revoke with refresh token', async () => {
     mockFetch.mockResolvedValue(new Response(null, { status: 200 }))
 
     const { revokeToken } = await import('./revoke-token')
     await revokeToken('rt-abc-123')
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.example.com/api/auth/social/token/revoke',
+      'https://api.example.com/auth/social/token/revoke',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/lib/auth/revoke-token.ts
+++ b/src/lib/auth/revoke-token.ts
@@ -5,7 +5,7 @@ export async function revokeToken(refreshToken: string): Promise<void> {
   }
 
   try {
-    const response = await fetch(`${apiUrl}/api/auth/social/token/revoke`, {
+    const response = await fetch(`${apiUrl}/auth/social/token/revoke`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refreshToken }),


### PR DESCRIPTION
## Summary
- Token refresh and revoke requests were hitting `/api/api/auth/social/token/...` (double `/api` prefix) because `API_URL` env var already includes `/api` and the auth helpers added it again
- This caused a 404 loop: refresh fails → session marked expired → redirect to login → session check → refresh fails → infinite reload
- Removed the extra `/api` prefix from `refresh-token.ts` and `revoke-token.ts`, and updated corresponding tests

## Test plan
- [x] All 30 auth unit tests pass (`npx vitest run src/lib/auth/`)
- [ ] Verify token refresh works after login (no 404s in backend logs)
- [ ] Verify authenticated pages load without reload loop
- [ ] Verify sign-out properly revokes tokens (no 404 on revoke endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)