### PR TITLE
fix(reports): align ReportType values with backend API contract

### DIFF
--- a/e2e/reports.spec.ts
+++ b/e2e/reports.spec.ts
@@ -44,7 +44,7 @@ test.describe('Reports page', () => {
     test('type filter pills are visible', async ({ authenticatedPage: page }) => {
       await navigateAndWait(page, '/reports')
       await expect(page.getByRole('button', { name: 'All Types' })).toBeVisible()
-      await expect(page.getByRole('button', { name: 'Lab Test' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Blood Test' })).toBeVisible()
     })
 
     test('pagination controls are visible with data', async ({ authenticatedPage: page }) => {

--- a/src/app/(portal)/access/page.test.tsx
+++ b/src/app/(portal)/access/page.test.tsx
@@ -104,7 +104,7 @@ const mockReports: ReportListResponse = {
     {
       id: 'r1',
       title: 'Complete Blood Count',
-      reportType: 'lab',
+      reportType: 'blood_test',
       status: 'verified',
       reportDate: '2025-01-15T00:00:00Z',
       labName: 'Thyrocare',
@@ -117,7 +117,7 @@ const mockReports: ReportListResponse = {
     {
       id: 'r2',
       title: 'Chest X-Ray',
-      reportType: 'imaging',
+      reportType: 'radiology',
       status: 'verified',
       reportDate: '2025-02-10T00:00:00Z',
       labName: null,

--- a/src/app/(portal)/reports/[id]/page.test.tsx
+++ b/src/app/(portal)/reports/[id]/page.test.tsx
@@ -66,7 +66,7 @@ function jsonResponse(data: unknown, status = 200) {
 const mockReport: ReportDetail = {
   id: 'r1',
   title: 'Complete Blood Count',
-  reportType: 'lab',
+  reportType: 'blood_test',
   status: 'verified',
   reportDate: '2025-01-15T00:00:00Z',
   labName: 'Thyrocare Labs',
@@ -150,7 +150,7 @@ describe('ReportDetailPage', () => {
       expect(screen.getByText('Complete Blood Count')).toBeInTheDocument()
     })
     expect(screen.getByText('Verified')).toBeInTheDocument()
-    expect(screen.getByText('Lab Test')).toBeInTheDocument()
+    expect(screen.getByText('Blood Test')).toBeInTheDocument()
     expect(screen.getByText('Thyrocare Labs')).toBeInTheDocument()
     expect(screen.getByText('Dr. Patel')).toBeInTheDocument()
   })

--- a/src/app/(portal)/reports/page.test.tsx
+++ b/src/app/(portal)/reports/page.test.tsx
@@ -38,7 +38,7 @@ const mockData: ReportListResponse = {
     {
       id: 'r1',
       title: 'Complete Blood Count',
-      reportType: 'lab',
+      reportType: 'blood_test',
       status: 'verified',
       reportDate: '2025-01-15T00:00:00Z',
       labName: 'Thyrocare Labs',
@@ -51,7 +51,7 @@ const mockData: ReportListResponse = {
     {
       id: 'r2',
       title: 'Chest X-Ray',
-      reportType: 'imaging',
+      reportType: 'radiology',
       status: 'pending',
       reportDate: '2025-02-10T00:00:00Z',
       labName: null,
@@ -157,14 +157,14 @@ describe('ReportsPage', () => {
       expect(screen.getByText('Complete Blood Count')).toBeInTheDocument()
     })
 
-    // Click "Lab Test" type filter — this triggers a new API call with category
-    await userEvent.click(screen.getByRole('button', { name: 'Lab Test' }))
+    // Click "Blood Test" type filter — this triggers a new API call with category
+    await userEvent.click(screen.getByRole('button', { name: 'Blood Test' }))
 
-    // The fetch should be called again with category=lab
+    // The fetch should be called again with category=blood_test
     await waitFor(() => {
       const calls = mockFetch.mock.calls
       const lastCallUrl = calls[calls.length - 1][0] as string
-      expect(lastCallUrl).toContain('category=lab')
+      expect(lastCallUrl).toContain('category=blood_test')
     })
   })
 

--- a/src/app/(portal)/reports/upload/page.test.tsx
+++ b/src/app/(portal)/reports/upload/page.test.tsx
@@ -194,7 +194,7 @@ describe('ReportUploadPage', () => {
         jsonResponse({
           id: 'report-1',
           title: 'blood-report',
-          reportType: 'lab',
+          reportType: 'blood_test',
           status: 'pending',
           reportDate: '2026-02-22',
           labName: null,
@@ -241,7 +241,7 @@ describe('ReportUploadPage', () => {
         jsonResponse({
           id: 'report-42',
           title: 'blood-report',
-          reportType: 'lab',
+          reportType: 'blood_test',
           status: 'pending',
           reportDate: '2026-02-22',
           labName: null,
@@ -377,7 +377,7 @@ describe('ReportUploadPage', () => {
         jsonResponse({
           id: 'report-1',
           title: 'blood-report',
-          reportType: 'lab',
+          reportType: 'blood_test',
           status: 'pending',
           reportDate: '2026-02-22',
           labName: null,

--- a/src/components/access/grant-modal.test.tsx
+++ b/src/components/access/grant-modal.test.tsx
@@ -35,7 +35,7 @@ const mockReports = {
     {
       id: 'r1',
       title: 'Complete Blood Count',
-      reportType: 'lab',
+      reportType: 'blood_test',
       status: 'verified',
       reportDate: '2025-01-15T00:00:00Z',
       labName: 'Thyrocare',
@@ -48,7 +48,7 @@ const mockReports = {
     {
       id: 'r2',
       title: 'Chest X-Ray',
-      reportType: 'imaging',
+      reportType: 'radiology',
       status: 'verified',
       reportDate: '2025-02-10T00:00:00Z',
       labName: null,

--- a/src/components/charts/report-timeline.test.tsx
+++ b/src/components/charts/report-timeline.test.tsx
@@ -52,7 +52,7 @@ vi.mock('framer-motion', () => ({
 function createReport(overrides: Partial<Report> & { id: string; reportDate: string }): Report {
   return {
     title: `Report ${overrides.id}`,
-    reportType: 'lab',
+    reportType: 'blood_test',
     status: 'verified',
     labName: null,
     doctorName: null,
@@ -68,26 +68,26 @@ const sampleReports: Report[] = [
   createReport({
     id: '1',
     title: 'Complete Blood Count',
-    reportType: 'lab',
+    reportType: 'blood_test',
     reportDate: '2025-01-20',
     highlightParameter: 'Hb: 14.2 g/dL',
   }),
   createReport({
     id: '2',
     title: 'Chest X-Ray',
-    reportType: 'imaging',
+    reportType: 'radiology',
     reportDate: '2025-01-15',
   }),
   createReport({
     id: '3',
     title: 'Discharge Summary',
-    reportType: 'discharge',
+    reportType: 'cardiology',
     reportDate: '2024-12-28',
   }),
   createReport({
     id: '4',
     title: 'Daily Medication',
-    reportType: 'prescription',
+    reportType: 'urine_test',
     reportDate: '2025-01-18',
   }),
   createReport({
@@ -133,10 +133,10 @@ describe('ReportTimeline', () => {
 
   it('renders report type labels for all types', () => {
     render(<ReportTimeline reports={sampleReports} onReportClick={vi.fn()} />)
-    expect(screen.getByText('Lab Test')).toBeInTheDocument()
-    expect(screen.getByText('Imaging')).toBeInTheDocument()
-    expect(screen.getByText('Discharge')).toBeInTheDocument()
-    expect(screen.getByText('Prescription')).toBeInTheDocument()
+    expect(screen.getByText('Blood Test')).toBeInTheDocument()
+    expect(screen.getByText('Radiology')).toBeInTheDocument()
+    expect(screen.getByText('Cardiology')).toBeInTheDocument()
+    expect(screen.getByText('Urine Test')).toBeInTheDocument()
     expect(screen.getByText('Other')).toBeInTheDocument()
   })
 

--- a/src/components/charts/report-timeline.tsx
+++ b/src/components/charts/report-timeline.tsx
@@ -39,7 +39,7 @@ function ReportTypeIcon({ type }: { type: ReportType }) {
   }
 
   switch (type) {
-    case 'lab':
+    case 'blood_test':
       return (
         <svg {...iconProps}>
           <path
@@ -51,14 +51,14 @@ function ReportTypeIcon({ type }: { type: ReportType }) {
           />
         </svg>
       )
-    case 'prescription':
+    case 'urine_test':
       return (
         <svg {...iconProps}>
           <rect x="3" y="2" width="10" height="12" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
           <path d="M6 5h4M6 7.5h4M6 10h2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
         </svg>
       )
-    case 'imaging':
+    case 'radiology':
       return (
         <svg {...iconProps}>
           <rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
@@ -66,7 +66,7 @@ function ReportTypeIcon({ type }: { type: ReportType }) {
           <path d="M5 3V2M11 3V2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
         </svg>
       )
-    case 'discharge':
+    case 'cardiology':
       return (
         <svg {...iconProps}>
           <path

--- a/src/components/reports/report-card-grid.test.tsx
+++ b/src/components/reports/report-card-grid.test.tsx
@@ -6,8 +6,8 @@ import type { Report } from '@/types/reports'
 const mockReports: Report[] = [
   {
     id: 'r1',
-    title: 'Blood Test',
-    reportType: 'lab',
+    title: 'Complete Blood Count',
+    reportType: 'blood_test',
     status: 'verified',
     reportDate: '2025-01-15T00:00:00Z',
     labName: 'Lab A',
@@ -20,7 +20,7 @@ const mockReports: Report[] = [
   {
     id: 'r2',
     title: 'X-Ray Report',
-    reportType: 'imaging',
+    reportType: 'radiology',
     status: 'pending',
     reportDate: '2025-02-10T00:00:00Z',
     labName: null,
@@ -65,7 +65,7 @@ describe('ReportCardGrid', () => {
     render(<ReportCardGrid {...defaultProps} />)
     expect(screen.getByTestId('report-grid')).toBeInTheDocument()
     expect(screen.getAllByTestId('report-card')).toHaveLength(2)
-    expect(screen.getByText('Blood Test')).toBeInTheDocument()
+    expect(screen.getByText('Complete Blood Count')).toBeInTheDocument()
     expect(screen.getByText('X-Ray Report')).toBeInTheDocument()
   })
 })

--- a/src/components/reports/report-card.test.tsx
+++ b/src/components/reports/report-card.test.tsx
@@ -7,7 +7,7 @@ import type { Report } from '@/types/reports'
 const mockReport: Report = {
   id: 'r1',
   title: 'Complete Blood Count',
-  reportType: 'lab',
+  reportType: 'blood_test',
   status: 'verified',
   reportDate: '2025-01-15T00:00:00Z',
   labName: 'Thyrocare Labs',
@@ -33,7 +33,7 @@ describe('ReportCard', () => {
 
   it('renders report type label', () => {
     render(<ReportCard {...defaultProps} />)
-    expect(screen.getByText('Lab Test')).toBeInTheDocument()
+    expect(screen.getByText('Blood Test')).toBeInTheDocument()
   })
 
   it('renders status badge', () => {

--- a/src/components/reports/report-constants.ts
+++ b/src/components/reports/report-constants.ts
@@ -2,10 +2,10 @@ import type { ReportType, ReportStatus, ParameterStatus } from '@/types/reports'
 import type { StatusBadgeProps } from '@/components/ui/status-badge'
 
 export const REPORT_TYPE_LABELS: Record<ReportType, string> = {
-  lab: 'Lab Test',
-  prescription: 'Prescription',
-  imaging: 'Imaging',
-  discharge: 'Discharge',
+  blood_test: 'Blood Test',
+  urine_test: 'Urine Test',
+  radiology: 'Radiology',
+  cardiology: 'Cardiology',
   other: 'Other',
 }
 
@@ -28,10 +28,10 @@ export interface FilterOption<T extends string> {
 
 export const TYPE_FILTER_OPTIONS: FilterOption<ReportType>[] = [
   { value: 'all', label: 'All Types' },
-  { value: 'lab', label: 'Lab Test' },
-  { value: 'prescription', label: 'Prescription' },
-  { value: 'imaging', label: 'Imaging' },
-  { value: 'discharge', label: 'Discharge' },
+  { value: 'blood_test', label: 'Blood Test' },
+  { value: 'urine_test', label: 'Urine Test' },
+  { value: 'radiology', label: 'Radiology' },
+  { value: 'cardiology', label: 'Cardiology' },
   { value: 'other', label: 'Other' },
 ]
 

--- a/src/components/reports/report-detail-header.test.tsx
+++ b/src/components/reports/report-detail-header.test.tsx
@@ -6,7 +6,7 @@ import type { ReportDetail } from '@/types/reports'
 const mockReport: ReportDetail = {
   id: 'r1',
   title: 'Complete Blood Count',
-  reportType: 'lab',
+  reportType: 'blood_test',
   status: 'verified',
   reportDate: '2025-01-15T00:00:00Z',
   labName: 'Thyrocare Labs',
@@ -34,7 +34,7 @@ describe('ReportDetailHeader', () => {
 
   it('renders report type label', () => {
     render(<ReportDetailHeader {...defaultProps} />)
-    expect(screen.getByText('Lab Test')).toBeInTheDocument()
+    expect(screen.getByText('Blood Test')).toBeInTheDocument()
   })
 
   it('renders status badge', () => {

--- a/src/components/reports/report-filter-bar.test.tsx
+++ b/src/components/reports/report-filter-bar.test.tsx
@@ -14,10 +14,10 @@ describe('ReportFilterBar', () => {
   it('renders all type filter options', () => {
     render(<ReportFilterBar {...defaultProps} />)
     expect(screen.getByRole('button', { name: 'All Types' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Lab Test' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Prescription' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Imaging' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Discharge' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Blood Test' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Urine Test' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Radiology' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cardiology' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Other' })).toBeInTheDocument()
   })
 
@@ -32,8 +32,8 @@ describe('ReportFilterBar', () => {
   it('calls onTypeChange when a type filter is clicked', async () => {
     const onTypeChange = vi.fn()
     render(<ReportFilterBar {...defaultProps} onTypeChange={onTypeChange} />)
-    await userEvent.click(screen.getByRole('button', { name: 'Lab Test' }))
-    expect(onTypeChange).toHaveBeenCalledWith('lab')
+    await userEvent.click(screen.getByRole('button', { name: 'Blood Test' }))
+    expect(onTypeChange).toHaveBeenCalledWith('blood_test')
   })
 
   it('calls onStatusChange when a status filter is clicked', async () => {

--- a/src/components/reports/upload-step-metadata.test.tsx
+++ b/src/components/reports/upload-step-metadata.test.tsx
@@ -33,10 +33,10 @@ describe('UploadStepMetadata', () => {
     render(<UploadStepMetadata {...defaultProps} />)
     const select = screen.getByLabelText('Report Type')
 
-    expect(select).toContainHTML('Lab Test')
-    expect(select).toContainHTML('Prescription')
-    expect(select).toContainHTML('Imaging')
-    expect(select).toContainHTML('Discharge')
+    expect(select).toContainHTML('Blood Test')
+    expect(select).toContainHTML('Urine Test')
+    expect(select).toContainHTML('Radiology')
+    expect(select).toContainHTML('Cardiology')
     expect(select).toContainHTML('Other')
   })
 
@@ -52,7 +52,7 @@ describe('UploadStepMetadata', () => {
 
     const submittedData = onSubmit.mock.calls[0][0]
     expect(submittedData.title).toBe('blood-report')
-    expect(submittedData.reportType).toBe('lab')
+    expect(submittedData.reportType).toBe('blood_test')
     expect(submittedData.reportDate).toBeTruthy()
   })
 

--- a/src/components/reports/upload-step-metadata.tsx
+++ b/src/components/reports/upload-step-metadata.tsx
@@ -10,7 +10,7 @@ import type { ReportType } from '@/types/reports'
 
 const metadataSchema = z.object({
   title: nonEmptyString.max(200, 'Title must be 200 characters or fewer'),
-  reportType: z.enum(['lab', 'prescription', 'imaging', 'discharge', 'other']),
+  reportType: z.enum(['blood_test', 'urine_test', 'radiology', 'cardiology', 'other']),
   reportDate: nonEmptyString.refine((v) => !isNaN(Date.parse(v)), 'Must be a valid date'),
   notes: z.string().max(500, 'Notes must be 500 characters or fewer').optional(),
 })
@@ -42,7 +42,7 @@ export function UploadStepMetadata({
     resolver: zodResolver(metadataSchema),
     defaultValues: {
       title: defaultTitle,
-      reportType: 'lab',
+      reportType: 'blood_test',
       reportDate: getTodayString(),
       notes: '',
     },

--- a/src/hooks/reports/use-create-report.test.tsx
+++ b/src/hooks/reports/use-create-report.test.tsx
@@ -42,7 +42,7 @@ describe('useCreateReport', () => {
     const created = {
       id: 'r1',
       title: 'Blood Test',
-      reportType: 'lab',
+      reportType: 'blood_test',
       status: 'pending',
       reportDate: '2025-01-15',
       labName: null,
@@ -61,7 +61,7 @@ describe('useCreateReport', () => {
     await act(() =>
       result.current.mutateAsync({
         title: 'Blood Test',
-        reportType: 'lab',
+        reportType: 'blood_test',
         reportDate: '2025-01-15',
         fileKey: 'uploads/abc123.pdf',
       }),
@@ -77,7 +77,7 @@ describe('useCreateReport', () => {
     expect(calledInit.method).toBe('POST')
     expect(JSON.parse(calledInit.body as string)).toEqual({
       title: 'Blood Test',
-      reportType: 'lab',
+      reportType: 'blood_test',
       reportDate: '2025-01-15',
       fileKey: 'uploads/abc123.pdf',
     })
@@ -88,7 +88,7 @@ describe('useCreateReport', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
     mockFetch.mockResolvedValue(
-      jsonResponse({ id: 'r1', title: 'Test', reportType: 'lab', status: 'pending', reportDate: '2025-01-15', labName: null, doctorName: null, notes: null, highlightParameter: null, createdAt: '2025-01-15T10:00:00Z', updatedAt: '2025-01-15T10:00:00Z' }),
+      jsonResponse({ id: 'r1', title: 'Test', reportType: 'blood_test', status: 'pending', reportDate: '2025-01-15', labName: null, doctorName: null, notes: null, highlightParameter: null, createdAt: '2025-01-15T10:00:00Z', updatedAt: '2025-01-15T10:00:00Z' }),
     )
 
     const { result } = renderHook(() => useCreateReport(), { wrapper })
@@ -96,7 +96,7 @@ describe('useCreateReport', () => {
     await act(() =>
       result.current.mutateAsync({
         title: 'Test',
-        reportType: 'lab',
+        reportType: 'blood_test',
         reportDate: '2025-01-15',
         fileKey: 'uploads/key.pdf',
       }),

--- a/src/hooks/reports/use-delete-report.test.tsx
+++ b/src/hooks/reports/use-delete-report.test.tsx
@@ -33,8 +33,8 @@ function createWrapper(gcTime = 0) {
   }
 }
 
-const reportOne = { id: 'r1', title: 'Report 1', reportType: 'lab' as const, status: 'verified' as const, reportDate: '2025-01-01', labName: null, doctorName: null, notes: null, highlightParameter: null, createdAt: '2025-01-01T00:00:00Z', updatedAt: '2025-01-01T00:00:00Z' }
-const reportTwo = { id: 'r2', title: 'Report 2', reportType: 'imaging' as const, status: 'pending' as const, reportDate: '2025-01-02', labName: null, doctorName: null, notes: null, highlightParameter: null, createdAt: '2025-01-02T00:00:00Z', updatedAt: '2025-01-02T00:00:00Z' }
+const reportOne = { id: 'r1', title: 'Report 1', reportType: 'blood_test' as const, status: 'verified' as const, reportDate: '2025-01-01', labName: null, doctorName: null, notes: null, highlightParameter: null, createdAt: '2025-01-01T00:00:00Z', updatedAt: '2025-01-01T00:00:00Z' }
+const reportTwo = { id: 'r2', title: 'Report 2', reportType: 'radiology' as const, status: 'pending' as const, reportDate: '2025-01-02', labName: null, doctorName: null, notes: null, highlightParameter: null, createdAt: '2025-01-02T00:00:00Z', updatedAt: '2025-01-02T00:00:00Z' }
 
 beforeEach(() => {
   mockFetch.mockReset()

--- a/src/hooks/reports/use-report.test.tsx
+++ b/src/hooks/reports/use-report.test.tsx
@@ -36,7 +36,7 @@ describe('useReport', () => {
     const detail = {
       id: 'r1',
       title: 'Blood Test',
-      reportType: 'lab',
+      reportType: 'blood_test',
       status: 'verified',
       reportDate: '2025-01-15',
       labName: 'PathLab',

--- a/src/hooks/reports/use-reports.test.tsx
+++ b/src/hooks/reports/use-reports.test.tsx
@@ -56,7 +56,7 @@ describe('useReports', () => {
     )
 
     const { result } = renderHook(
-      () => useReports({ page: 2, pageSize: 5, search: 'blood', category: 'lab' }),
+      () => useReports({ page: 2, pageSize: 5, search: 'blood', category: 'blood_test' }),
       { wrapper: createWrapper() },
     )
 
@@ -66,7 +66,7 @@ describe('useReports', () => {
     expect(calledUrl).toContain('page=2')
     expect(calledUrl).toContain('pageSize=5')
     expect(calledUrl).toContain('search=blood')
-    expect(calledUrl).toContain('category=lab')
+    expect(calledUrl).toContain('category=blood_test')
   })
 
   it('returns error state on failure', async () => {

--- a/src/lib/schemas/reportUpload.test.ts
+++ b/src/lib/schemas/reportUpload.test.ts
@@ -14,7 +14,7 @@ function makeFile(
 const validData = {
   file: makeFile('report.pdf', 'application/pdf', 1024),
   title: 'Blood Test Results',
-  reportType: 'lab' as const,
+  reportType: 'blood_test' as const,
   reportDate: new Date('2024-01-15'),
 }
 

--- a/src/lib/schemas/reportUpload.ts
+++ b/src/lib/schemas/reportUpload.ts
@@ -14,7 +14,7 @@ export const reportUploadSchema = z.object({
       'Only PDF, JPEG, and PNG files are allowed',
     ),
   title: nonEmptyString.max(200, 'Title must be 200 characters or fewer'),
-  reportType: z.enum(['lab', 'prescription', 'imaging', 'discharge', 'other']),
+  reportType: z.enum(['blood_test', 'urine_test', 'radiology', 'cardiology', 'other']),
   reportDate: z.coerce.date(),
   notes: z.string().max(500, 'Notes must be 500 characters or fewer').optional(),
 })

--- a/src/types/reports.ts
+++ b/src/types/reports.ts
@@ -1,4 +1,4 @@
-export type ReportType = 'lab' | 'prescription' | 'imaging' | 'discharge' | 'other'
+export type ReportType = 'blood_test' | 'urine_test' | 'radiology' | 'cardiology' | 'other'
 
 export type ReportStatus = 'pending' | 'processing' | 'verified'
 


### PR DESCRIPTION
## Summary
- Replace frontend ReportType values (lab, prescription, imaging, discharge) with backend-expected values (blood_test, urine_test, radiology, cardiology)
- Update display labels: Blood Test, Urine Test, Radiology, Cardiology, Other
- Update Zod schemas, filter options, form defaults, switch cases, and all test fixtures (22 files)

Closes #120

## Test plan
- [x] npm run type-check passes
- [x] npm run lint passes (no new warnings)
- [x] npm run test — 1343/1347 tests pass; 4 pre-existing failures in verified-download.test.ts (unrelated object.stream issue)
- [ ] Verify report upload sends correct reportType value to backend
- [ ] Verify filter bar labels display correctly
- [ ] Verify report detail page shows correct type label

Generated with Claude Code