### PR TITLE
fix(reports): align ExtractionStatusResponse enum values with backend API

### DIFF
--- a/src/app/(portal)/reports/[id]/page.test.tsx
+++ b/src/app/(portal)/reports/[id]/page.test.tsx
@@ -107,9 +107,10 @@ const mockReport: ReportDetail = {
 }
 
 const mockExtraction: ExtractionStatusResponse = {
-  status: 'completed',
-  extractionMethod: 'ocr',
-  structuringModel: 'gpt-4o',
+  reportId: 'r1',
+  status: 'extracted',
+  extractionMethod: 'pdfpig',
+  structuringModel: 'qwen2.5:14b-instruct',
   extractedParameterCount: 2,
   overallConfidence: 0.95,
   pageCount: 1,

--- a/src/components/reports/extraction-status-card.test.tsx
+++ b/src/components/reports/extraction-status-card.test.tsx
@@ -7,8 +7,8 @@ import {
 } from './extraction-status-card'
 
 const defaultProps: ExtractionStatusCardProps = {
-  status: 'completed',
-  extractionMethod: 'ocr',
+  status: 'extracted',
+  extractionMethod: 'pdfpig',
   structuringModel: 'gpt-4o',
   extractedParameterCount: 12,
   overallConfidence: 0.95,
@@ -37,7 +37,7 @@ describe('ExtractionStatusCard', () => {
   it('displays extraction method', () => {
     renderCard()
     expect(screen.getByText('Method')).toBeInTheDocument()
-    expect(screen.getByText('OCR')).toBeInTheDocument()
+    expect(screen.getByText('PDF Text')).toBeInTheDocument()
   })
 
   it('displays structuring model', () => {
@@ -75,59 +75,48 @@ describe('ExtractionStatusCard', () => {
     expect(screen.getByText('1')).toBeInTheDocument()
   })
 
-  it('shows Re-extract button for completed status', () => {
-    renderCard({ status: 'completed' })
+  it('shows Re-extract button for extracted status', () => {
+    renderCard({ status: 'extracted' })
     expect(screen.getByRole('button', { name: /Re-extract/i })).toBeInTheDocument()
   })
 
-  it('shows Re-extract button for failed status', () => {
-    renderCard({ status: 'failed', errorMessage: 'Parse error' })
+  it('shows Re-extract button for extraction_failed status', () => {
+    renderCard({ status: 'extraction_failed', errorMessage: 'Parse error' })
     expect(screen.getByRole('button', { name: /Re-extract/i })).toBeInTheDocument()
   })
 
-  it('does not show Re-extract button for pending status', () => {
-    renderCard({ status: 'pending' })
-    expect(screen.queryByRole('button', { name: /Re-extract/i })).not.toBeInTheDocument()
-  })
-
-  it('does not show Re-extract button for processing status', () => {
-    renderCard({ status: 'processing' })
+  it('does not show Re-extract button for extracting status', () => {
+    renderCard({ status: 'extracting' })
     expect(screen.queryByRole('button', { name: /Re-extract/i })).not.toBeInTheDocument()
   })
 
   it('calls onTriggerExtraction when Re-extract is clicked', async () => {
     const onTrigger = vi.fn()
-    renderCard({ status: 'failed', errorMessage: 'Error', onTriggerExtraction: onTrigger })
+    renderCard({ status: 'extraction_failed', errorMessage: 'Error', onTriggerExtraction: onTrigger })
 
     await userEvent.click(screen.getByRole('button', { name: /Re-extract/i }))
     expect(onTrigger).toHaveBeenCalledTimes(1)
   })
 
-  it('shows progress indicator for pending status', () => {
-    renderCard({ status: 'pending' })
-    expect(screen.getByTestId('extraction-progress')).toBeInTheDocument()
-    expect(screen.getByText(/queued/i)).toBeInTheDocument()
-  })
-
-  it('shows progress indicator for processing status', () => {
-    renderCard({ status: 'processing' })
+  it('shows progress indicator for extracting status', () => {
+    renderCard({ status: 'extracting' })
     expect(screen.getByTestId('extraction-progress')).toBeInTheDocument()
     expect(screen.getByText(/Extracting parameters/i)).toBeInTheDocument()
   })
 
-  it('does not show progress indicator for completed status', () => {
-    renderCard({ status: 'completed' })
+  it('does not show progress indicator for extracted status', () => {
+    renderCard({ status: 'extracted' })
     expect(screen.queryByTestId('extraction-progress')).not.toBeInTheDocument()
   })
 
-  it('shows error message for failed status', () => {
-    renderCard({ status: 'failed', errorMessage: 'Unable to parse document' })
+  it('shows error message for extraction_failed status', () => {
+    renderCard({ status: 'extraction_failed', errorMessage: 'Unable to parse document' })
     expect(screen.getByTestId('extraction-error')).toBeInTheDocument()
     expect(screen.getByText('Unable to parse document')).toBeInTheDocument()
   })
 
   it('does not show error alert when no error message', () => {
-    renderCard({ status: 'failed', errorMessage: null })
+    renderCard({ status: 'extraction_failed', errorMessage: null })
     expect(screen.queryByTestId('extraction-error')).not.toBeInTheDocument()
   })
 
@@ -166,14 +155,14 @@ describe('ExtractionStatusCard', () => {
     expect(screen.queryByText('Attempts')).not.toBeInTheDocument()
   })
 
-  it('displays native_text method label correctly', () => {
-    renderCard({ extractionMethod: 'native_text' })
-    expect(screen.getByText('Native Text')).toBeInTheDocument()
+  it('displays textract method label correctly', () => {
+    renderCard({ extractionMethod: 'textract' })
+    expect(screen.getByText('Textract')).toBeInTheDocument()
   })
 
-  it('displays hybrid method label correctly', () => {
-    renderCard({ extractionMethod: 'hybrid' })
-    expect(screen.getByText('Hybrid')).toBeInTheDocument()
+  it('displays pdfpig+textract method label correctly', () => {
+    renderCard({ extractionMethod: 'pdfpig+textract' })
+    expect(screen.getByText('PDF Text + Textract')).toBeInTheDocument()
   })
 
   it('formats low confidence correctly', () => {

--- a/src/components/reports/extraction-status-card.tsx
+++ b/src/components/reports/extraction-status-card.tsx
@@ -19,24 +19,25 @@ export interface ExtractionStatusCardProps {
   isTriggerPending: boolean
 }
 
-const STATUS_BADGE_VARIANT: Record<ExtractionStatus, StatusBadgeProps['variant']> = {
-  pending: 'pending',
-  processing: 'warning',
-  completed: 'success',
-  failed: 'error',
+function getStatusBadgeVariant(status: ExtractionStatus): StatusBadgeProps['variant'] {
+  if (status === 'extracted') return 'success'
+  if (status === 'extraction_failed') return 'error'
+  if (status === 'extracting') return 'warning'
+  return 'pending'
 }
 
-const STATUS_LABELS: Record<ExtractionStatus, string> = {
-  pending: 'Pending',
-  processing: 'Processing',
-  completed: 'Completed',
-  failed: 'Failed',
+function getStatusLabel(status: ExtractionStatus): string {
+  if (status === 'extracted') return 'Completed'
+  if (status === 'extraction_failed') return 'Failed'
+  if (status === 'extracting') return 'Extracting'
+  return 'Pending'
 }
 
-const METHOD_LABELS: Record<ExtractionMethod, string> = {
-  ocr: 'OCR',
-  native_text: 'Native Text',
-  hybrid: 'Hybrid',
+function getMethodLabel(method: ExtractionMethod): string {
+  if (method === 'pdfpig') return 'PDF Text'
+  if (method === 'textract') return 'Textract'
+  if (method === 'pdfpig+textract') return 'PDF Text + Textract'
+  return method
 }
 
 function RefreshIcon() {
@@ -94,8 +95,8 @@ export function ExtractionStatusCard({
   onTriggerExtraction,
   isTriggerPending,
 }: ExtractionStatusCardProps) {
-  const canRetrigger = status === 'failed' || status === 'completed'
-  const isActive = status === 'pending' || status === 'processing'
+  const canRetrigger = status === 'extraction_failed' || status === 'extracted'
+  const isActive = status === 'extracting'
 
   return (
     <Box
@@ -111,8 +112,8 @@ export function ExtractionStatusCard({
         <Text fontSize="md" fontWeight="semibold" color="text.primary">
           AI Extraction
         </Text>
-        <StatusBadge variant={STATUS_BADGE_VARIANT[status]}>
-          {STATUS_LABELS[status]}
+        <StatusBadge variant={getStatusBadgeVariant(status)}>
+          {getStatusLabel(status)}
         </StatusBadge>
       </Flex>
 
@@ -135,15 +136,13 @@ export function ExtractionStatusCard({
               animation="pulse 1.5s ease-in-out infinite"
             />
             <Text fontSize="sm" color="text.secondary">
-              {status === 'pending'
-                ? 'Extraction queued, waiting to start...'
-                : 'Extracting parameters from your report...'}
+              Extracting parameters from your report...
             </Text>
           </Flex>
         </Box>
       )}
 
-      {status === 'failed' && errorMessage && (
+      {status === 'extraction_failed' && errorMessage && (
         <Box
           bg="red.50"
           color="red.700"
@@ -161,7 +160,7 @@ export function ExtractionStatusCard({
       )}
 
       {extractionMethod && (
-        <DetailRow label="Method" value={METHOD_LABELS[extractionMethod]} />
+        <DetailRow label="Method" value={getMethodLabel(extractionMethod)} />
       )}
       {structuringModel && (
         <DetailRow label="Model" value={structuringModel} />

--- a/src/hooks/reports/use-extraction-status.test.tsx
+++ b/src/hooks/reports/use-extraction-status.test.tsx
@@ -28,9 +28,10 @@ function createWrapper() {
 }
 
 const completedExtraction: ExtractionStatusResponse = {
-  status: 'completed',
-  extractionMethod: 'ocr',
-  structuringModel: 'gpt-4o',
+  reportId: 'r1',
+  status: 'extracted',
+  extractionMethod: 'pdfpig',
+  structuringModel: 'qwen2.5:14b-instruct',
   extractedParameterCount: 12,
   overallConfidence: 0.95,
   pageCount: 3,
@@ -40,7 +41,8 @@ const completedExtraction: ExtractionStatusResponse = {
 }
 
 const processingExtraction: ExtractionStatusResponse = {
-  status: 'processing',
+  reportId: 'r1',
+  status: 'extracting',
   extractionMethod: null,
   structuringModel: null,
   extractedParameterCount: 0,
@@ -114,7 +116,7 @@ describe('useExtractionStatus', () => {
     })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data?.status).toBe('processing')
+    expect(result.current.data?.status).toBe('extracting')
   })
 
   it('does not poll for completed status', async () => {
@@ -125,15 +127,16 @@ describe('useExtractionStatus', () => {
     })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data?.status).toBe('completed')
+    expect(result.current.data?.status).toBe('extracted')
     // Completed status should not trigger polling — only 1 call
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 
   it('returns failed extraction with error message', async () => {
     const failedExtraction: ExtractionStatusResponse = {
-      status: 'failed',
-      extractionMethod: 'ocr',
+      reportId: 'r1',
+      status: 'extraction_failed',
+      extractionMethod: 'pdfpig',
       structuringModel: null,
       extractedParameterCount: 0,
       overallConfidence: null,
@@ -149,7 +152,7 @@ describe('useExtractionStatus', () => {
     })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data?.status).toBe('failed')
+    expect(result.current.data?.status).toBe('extraction_failed')
     expect(result.current.data?.errorMessage).toBe('Unable to parse document')
   })
 })

--- a/src/hooks/reports/use-extraction-status.ts
+++ b/src/hooks/reports/use-extraction-status.ts
@@ -15,7 +15,7 @@ export function useExtractionStatus(reportId: string) {
     enabled: !!reportId,
     refetchInterval: (query) => {
       const status = query.state.data?.status
-      if (status === 'pending' || status === 'processing') {
+      if (status === 'extracting') {
         return 3000
       }
       return false

--- a/src/hooks/reports/use-trigger-extraction.test.tsx
+++ b/src/hooks/reports/use-trigger-extraction.test.tsx
@@ -34,7 +34,8 @@ function createWrapper() {
 }
 
 const triggerResponse: ExtractionStatusResponse = {
-  status: 'processing',
+  reportId: 'r1',
+  status: 'extracting',
   extractionMethod: null,
   structuringModel: null,
   extractedParameterCount: 0,

--- a/src/types/reports.ts
+++ b/src/types/reports.ts
@@ -142,11 +142,12 @@ export interface VerifiedDownloadUrlResponse {
   isServerVerified: boolean
 }
 
-export type ExtractionStatus = 'pending' | 'processing' | 'completed' | 'failed'
+export type ExtractionStatus = 'extracting' | 'extracted' | 'extraction_failed' | string
 
-export type ExtractionMethod = 'ocr' | 'native_text' | 'hybrid'
+export type ExtractionMethod = 'pdfpig' | 'textract' | 'pdfpig+textract' | string
 
 export interface ExtractionStatusResponse {
+  reportId: string
   status: ExtractionStatus
   extractionMethod: ExtractionMethod | null
   structuringModel: string | null


### PR DESCRIPTION
## Summary
- Updated `ExtractionStatus` type: `'extracted'` (not `'completed'`), `'extraction_failed'` (not `'failed'`), `'extracting'` (not `'processing'`)
- Updated `ExtractionMethod` type: `'pdfpig'`/`'textract'`/`'pdfpig+textract'` (not `'ocr'`/`'native_text'`/`'hybrid'`)
- Added missing `reportId` field to `ExtractionStatusResponse`
- Converted `extraction-status-card` from static Record-based label lookups to helper functions (`getStatusBadgeVariant`, `getStatusLabel`, `getMethodLabel`) for more flexible mapping
- Updated polling logic in `use-extraction-status` hook to poll when `status === 'extracting'` instead of `'pending'` or `'processing'`
- Updated all affected test mocks and assertions across 4 test files

Fixes the contract mismatch identified in the API contract verification report (Critical Issue #1).

## Test plan
- [x] `npm run type-check` — zero errors
- [x] `npm run test` — all 1338 tests pass (140 files)
- [x] `npm run lint` — zero errors
- [ ] CI checks pass on PR
- [ ] Manual verification: extraction status card displays correctly with real API values

🤖 Generated with [Claude Code](https://claude.com/claude-code)