### PR TITLE
fix: align consent types with backend API contract

### DIFF
--- a/src/app/(portal)/settings/page.test.tsx
+++ b/src/app/(portal)/settings/page.test.tsx
@@ -35,14 +35,12 @@ const mockProfile: Profile = {
   roles: ['patient'],
 }
 
-const mockConsents: ConsentListResponse = {
-  items: [
-    { id: 'c1', purpose: 'analytics', granted: true, updatedAt: '2025-06-01T00:00:00Z' },
-    { id: 'c2', purpose: 'marketing', granted: false, updatedAt: '2025-05-15T00:00:00Z' },
-    { id: 'c3', purpose: 'data-sharing', granted: true, updatedAt: '2025-04-20T00:00:00Z' },
-    { id: 'c4', purpose: 'research', granted: false, updatedAt: '2025-03-10T00:00:00Z' },
-  ],
-}
+const mockConsents: ConsentListResponse = [
+  { purpose: 'analytics', isGranted: true, occurredAt: '2025-06-01T00:00:00Z', source: 'api' },
+  { purpose: 'marketing', isGranted: false, occurredAt: '2025-05-15T00:00:00Z', source: 'api' },
+  { purpose: 'data-sharing', isGranted: true, occurredAt: '2025-04-20T00:00:00Z', source: 'api' },
+  { purpose: 'research', isGranted: false, occurredAt: '2025-03-10T00:00:00Z', source: 'api' },
+]
 
 const mockNotificationPrefs: NotificationPreferences = {
   reportUploaded: {

--- a/src/components/settings/consents-section.test.tsx
+++ b/src/components/settings/consents-section.test.tsx
@@ -14,34 +14,32 @@ function jsonResponse(data: unknown, status = 200) {
   })
 }
 
-const mockConsents: ConsentListResponse = {
-  items: [
-    {
-      id: 'c1',
-      purpose: 'analytics',
-      granted: true,
-      updatedAt: '2025-06-01T00:00:00Z',
-    },
-    {
-      id: 'c2',
-      purpose: 'marketing',
-      granted: false,
-      updatedAt: '2025-05-15T00:00:00Z',
-    },
-    {
-      id: 'c3',
-      purpose: 'data-sharing',
-      granted: true,
-      updatedAt: '2025-04-20T00:00:00Z',
-    },
-    {
-      id: 'c4',
-      purpose: 'research',
-      granted: false,
-      updatedAt: '2025-03-10T00:00:00Z',
-    },
-  ],
-}
+const mockConsents: ConsentListResponse = [
+  {
+    purpose: 'analytics',
+    isGranted: true,
+    occurredAt: '2025-06-01T00:00:00Z',
+    source: 'api',
+  },
+  {
+    purpose: 'marketing',
+    isGranted: false,
+    occurredAt: '2025-05-15T00:00:00Z',
+    source: 'api',
+  },
+  {
+    purpose: 'data-sharing',
+    isGranted: true,
+    occurredAt: '2025-04-20T00:00:00Z',
+    source: 'api',
+  },
+  {
+    purpose: 'research',
+    isGranted: false,
+    occurredAt: '2025-03-10T00:00:00Z',
+    source: 'api',
+  },
+]
 
 beforeEach(() => {
   mockFetch.mockReset()
@@ -98,7 +96,7 @@ describe('ConsentsSection', () => {
     })
 
     mockFetch.mockResolvedValue(
-      jsonResponse({ id: 'c2', purpose: 'marketing', granted: true, updatedAt: new Date().toISOString() }),
+      jsonResponse({ purpose: 'marketing', isGranted: true, occurredAt: new Date().toISOString(), source: 'api' }),
     )
 
     await userEvent.click(screen.getByTestId('consent-switch-marketing'))
@@ -112,7 +110,7 @@ describe('ConsentsSection', () => {
       })
       expect(putCall).toBeTruthy()
       const body = JSON.parse((putCall![1] as RequestInit).body as string)
-      expect(body.granted).toBe(true)
+      expect(body.isGranted).toBe(true)
     })
   })
 
@@ -149,7 +147,7 @@ describe('ConsentsSection', () => {
     })
 
     mockFetch.mockResolvedValue(
-      jsonResponse({ id: 'c1', purpose: 'analytics', granted: false, updatedAt: new Date().toISOString() }),
+      jsonResponse({ purpose: 'analytics', isGranted: false, occurredAt: new Date().toISOString(), source: 'api' }),
     )
 
     await userEvent.click(screen.getByRole('button', { name: 'Revoke' }))
@@ -163,7 +161,7 @@ describe('ConsentsSection', () => {
       })
       expect(putCall).toBeTruthy()
       const body = JSON.parse((putCall![1] as RequestInit).body as string)
-      expect(body.granted).toBe(false)
+      expect(body.isGranted).toBe(false)
     })
   })
 

--- a/src/components/settings/consents-section.tsx
+++ b/src/components/settings/consents-section.tsx
@@ -15,16 +15,16 @@ export function ConsentsSection() {
   const [revokePurpose, setRevokePurpose] = useState<ConsentPurpose | null>(null)
 
   const consentMap = useMemo(() => {
-    if (!data?.items) return new Map<ConsentPurpose, { granted: boolean; updatedAt: string }>()
+    if (!data) return new Map<ConsentPurpose, { isGranted: boolean; occurredAt: string }>()
     return new Map(
-      data.items.map((c) => [c.purpose, { granted: c.granted, updatedAt: c.updatedAt }]),
+      data.map((c) => [c.purpose, { isGranted: c.isGranted, occurredAt: c.occurredAt }]),
     )
   }, [data])
 
   const handleToggle = useCallback(
     (purpose: ConsentPurpose, granted: boolean) => {
       if (granted) {
-        updateConsent.mutate({ purpose, granted: true })
+        updateConsent.mutate({ purpose, isGranted: true })
       } else {
         setRevokePurpose(purpose)
       }
@@ -34,7 +34,7 @@ export function ConsentsSection() {
 
   const handleConfirmRevoke = useCallback(() => {
     if (revokePurpose) {
-      updateConsent.mutate({ purpose: revokePurpose, granted: false })
+      updateConsent.mutate({ purpose: revokePurpose, isGranted: false })
       setRevokePurpose(null)
     }
   }, [revokePurpose, updateConsent])
@@ -76,8 +76,8 @@ export function ConsentsSection() {
             <ConsentToggleRow
               key={meta.purpose}
               meta={meta}
-              granted={consent?.granted ?? false}
-              updatedAt={consent?.updatedAt ?? new Date().toISOString()}
+              granted={consent?.isGranted ?? false}
+              updatedAt={consent?.occurredAt ?? new Date().toISOString()}
               showBorder={i > 0}
               onToggle={(granted) => handleToggle(meta.purpose, granted)}
             />

--- a/src/hooks/consents/use-consents.test.tsx
+++ b/src/hooks/consents/use-consents.test.tsx
@@ -33,22 +33,20 @@ beforeEach(() => {
 
 describe('useConsents', () => {
   it('fetches consents successfully', async () => {
-    const data = {
-      items: [
-        {
-          id: 'c1',
-          purpose: 'analytics',
-          granted: true,
-          updatedAt: '2025-06-01T00:00:00Z',
-        },
-        {
-          id: 'c2',
-          purpose: 'marketing',
-          granted: false,
-          updatedAt: '2025-05-15T00:00:00Z',
-        },
-      ],
-    }
+    const data = [
+      {
+        purpose: 'analytics',
+        isGranted: true,
+        occurredAt: '2025-06-01T00:00:00Z',
+        source: 'api',
+      },
+      {
+        purpose: 'marketing',
+        isGranted: false,
+        occurredAt: '2025-05-15T00:00:00Z',
+        source: 'api',
+      },
+    ]
     mockFetch.mockResolvedValue(jsonResponse(data))
 
     const { result } = renderHook(() => useConsents(), {

--- a/src/hooks/consents/use-update-consent.test.tsx
+++ b/src/hooks/consents/use-update-consent.test.tsx
@@ -41,10 +41,10 @@ beforeEach(() => {
 describe('useUpdateConsent', () => {
   it('sends PUT request with correct URL and body', async () => {
     const updated = {
-      id: 'c1',
       purpose: 'analytics',
-      granted: false,
-      updatedAt: '2025-06-15T10:00:00Z',
+      isGranted: false,
+      occurredAt: '2025-06-15T10:00:00Z',
+      source: 'api',
     }
     mockFetch.mockResolvedValue(jsonResponse(updated))
 
@@ -55,7 +55,7 @@ describe('useUpdateConsent', () => {
     await act(() =>
       result.current.mutateAsync({
         purpose: 'analytics',
-        granted: false,
+        isGranted: false,
       }),
     )
 
@@ -68,28 +68,26 @@ describe('useUpdateConsent', () => {
     expect(calledInit.method).toBe('PUT')
 
     const body = JSON.parse(calledInit.body as string)
-    expect(body).toEqual({ granted: false })
+    expect(body).toEqual({ isGranted: false })
   })
 
   it('optimistically updates consent in cache', async () => {
     const wrapper = createWrapper(Infinity)
 
-    const initialData: ConsentListResponse = {
-      items: [
-        {
-          id: 'c1',
-          purpose: 'analytics',
-          granted: true,
-          updatedAt: '2025-06-01T00:00:00Z',
-        },
-        {
-          id: 'c2',
-          purpose: 'marketing',
-          granted: false,
-          updatedAt: '2025-05-15T00:00:00Z',
-        },
-      ],
-    }
+    const initialData: ConsentListResponse = [
+      {
+        purpose: 'analytics',
+        isGranted: true,
+        occurredAt: '2025-06-01T00:00:00Z',
+        source: 'api',
+      },
+      {
+        purpose: 'marketing',
+        isGranted: false,
+        occurredAt: '2025-05-15T00:00:00Z',
+        source: 'api',
+      },
+    ]
 
     queryClient.setQueryData(queryKeys.consents.list(), initialData)
 
@@ -99,10 +97,10 @@ describe('useUpdateConsent', () => {
         resolveUpdate = () =>
           resolve(
             jsonResponse({
-              id: 'c1',
               purpose: 'analytics',
-              granted: false,
-              updatedAt: '2025-06-15T10:00:00Z',
+              isGranted: false,
+              occurredAt: '2025-06-15T10:00:00Z',
+              source: 'api',
             }),
           )
       }),
@@ -113,7 +111,7 @@ describe('useUpdateConsent', () => {
     await act(async () => {
       result.current.mutate({
         purpose: 'analytics',
-        granted: false,
+        isGranted: false,
       })
     })
 
@@ -121,7 +119,7 @@ describe('useUpdateConsent', () => {
       const cached = queryClient.getQueryData<ConsentListResponse>(
         queryKeys.consents.list(),
       )
-      expect(cached?.items[0].granted).toBe(false)
+      expect(cached?.[0].isGranted).toBe(false)
     })
 
     await act(async () => {
@@ -132,16 +130,14 @@ describe('useUpdateConsent', () => {
   it('rolls back cache on error', async () => {
     const wrapper = createWrapper(Infinity)
 
-    const initialData: ConsentListResponse = {
-      items: [
-        {
-          id: 'c1',
-          purpose: 'analytics',
-          granted: true,
-          updatedAt: '2025-06-01T00:00:00Z',
-        },
-      ],
-    }
+    const initialData: ConsentListResponse = [
+      {
+        purpose: 'analytics',
+        isGranted: true,
+        occurredAt: '2025-06-01T00:00:00Z',
+        source: 'api',
+      },
+    ]
 
     queryClient.setQueryData(queryKeys.consents.list(), initialData)
 
@@ -154,7 +150,7 @@ describe('useUpdateConsent', () => {
     await act(async () => {
       result.current.mutate({
         purpose: 'analytics',
-        granted: false,
+        isGranted: false,
       })
     })
 
@@ -164,7 +160,7 @@ describe('useUpdateConsent', () => {
       const cached = queryClient.getQueryData<ConsentListResponse>(
         queryKeys.consents.list(),
       )
-      expect(cached?.items[0].granted).toBe(true)
+      expect(cached?.[0].isGranted).toBe(true)
     })
   })
 })

--- a/src/hooks/consents/use-update-consent.ts
+++ b/src/hooks/consents/use-update-consent.ts
@@ -17,7 +17,7 @@ export function useUpdateConsent() {
         method: 'PUT',
         body: request,
       }),
-    onMutate: async ({ purpose, granted }) => {
+    onMutate: async ({ purpose, isGranted }) => {
       await queryClient.cancelQueries({ queryKey: queryKeys.consents.all })
 
       const previousLists = queryClient.getQueriesData<ConsentListResponse>(
@@ -27,15 +27,12 @@ export function useUpdateConsent() {
       queryClient.setQueriesData<ConsentListResponse>(
         { queryKey: queryKeys.consents.all },
         (old) => {
-          if (!old?.items) return old
-          return {
-            ...old,
-            items: old.items.map((c) =>
-              c.purpose === purpose
-                ? { ...c, granted, updatedAt: new Date().toISOString() }
-                : c,
-            ),
-          }
+          if (!old) return old
+          return old.map((c) =>
+            c.purpose === purpose
+              ? { ...c, isGranted, occurredAt: new Date().toISOString() }
+              : c,
+          )
         },
       )
 

--- a/src/lib/schemas/consent.test.ts
+++ b/src/lib/schemas/consent.test.ts
@@ -4,7 +4,7 @@ import { consentSchema } from './consent'
 
 const validData = {
   purpose: 'analytics' as const,
-  granted: true,
+  isGranted: true,
 }
 
 describe('consentSchema', () => {
@@ -12,10 +12,10 @@ describe('consentSchema', () => {
     expect(consentSchema.safeParse(validData).success).toBe(true)
   })
 
-  it('accepts granted as false', () => {
+  it('accepts isGranted as false', () => {
     const result = consentSchema.safeParse({
       ...validData,
-      granted: false,
+      isGranted: false,
     })
     expect(result.success).toBe(true)
   })
@@ -36,10 +36,10 @@ describe('consentSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects non-boolean granted', () => {
+  it('rejects non-boolean isGranted', () => {
     const result = consentSchema.safeParse({
       ...validData,
-      granted: 'yes',
+      isGranted: 'yes',
     })
     expect(result.success).toBe(false)
   })

--- a/src/lib/schemas/consent.ts
+++ b/src/lib/schemas/consent.ts
@@ -2,7 +2,7 @@ import { z } from 'zod/v4'
 
 export const consentSchema = z.object({
   purpose: z.enum(['analytics', 'marketing', 'data-sharing', 'research']),
-  granted: z.boolean(),
+  isGranted: z.boolean(),
 })
 
 export type Consent = z.infer<typeof consentSchema>

--- a/src/types/consent.ts
+++ b/src/types/consent.ts
@@ -1,16 +1,14 @@
 export type ConsentPurpose = 'analytics' | 'marketing' | 'data-sharing' | 'research'
 
 export interface Consent {
-  id: string
   purpose: ConsentPurpose
-  granted: boolean
-  updatedAt: string
+  isGranted: boolean
+  occurredAt: string
+  source: string
 }
 
-export interface ConsentListResponse {
-  items: Consent[]
-}
+export type ConsentListResponse = Consent[]
 
 export interface UpdateConsentRequest {
-  granted: boolean
+  isGranted: boolean
 }


### PR DESCRIPTION
## Summary
- Fixed request body sending `granted` instead of `isGranted` (causing 400 Bad Request on PUT `/v1/consents/{purpose}`)
- Fixed response type expecting `{ items: [...] }` wrapper — backend returns a plain `ConsentRecordResponse[]` array
- Aligned response field names: `granted`→`isGranted`, `updatedAt`→`occurredAt`, added missing `source` field

## Test plan
- [x] `npm run type-check` passes
- [x] All 1343 tests pass (140 test files)
- [ ] Verify consent toggle on https://dev.kinvee.in/settings works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)