### PR TITLE
fix: align consent purposes with backend catalog

### DIFF
--- a/src/app/(portal)/settings/page.test.tsx
+++ b/src/app/(portal)/settings/page.test.tsx
@@ -36,10 +36,10 @@ const mockProfile: Profile = {
 }
 
 const mockConsents: ConsentListResponse = [
-  { purpose: 'analytics', isGranted: true, occurredAt: '2025-06-01T00:00:00Z', source: 'api' },
-  { purpose: 'marketing', isGranted: false, occurredAt: '2025-05-15T00:00:00Z', source: 'api' },
-  { purpose: 'data-sharing', isGranted: true, occurredAt: '2025-04-20T00:00:00Z', source: 'api' },
-  { purpose: 'research', isGranted: false, occurredAt: '2025-03-10T00:00:00Z', source: 'api' },
+  { purpose: 'profile_management', isGranted: true, occurredAt: '2025-06-01T00:00:00Z', source: 'api' },
+  { purpose: 'emergency_contact_management', isGranted: false, occurredAt: '2025-05-15T00:00:00Z', source: 'api' },
+  { purpose: 'medical_data_sharing', isGranted: true, occurredAt: '2025-04-20T00:00:00Z', source: 'api' },
+  { purpose: 'medical_records_processing', isGranted: false, occurredAt: '2025-03-10T00:00:00Z', source: 'api' },
 ]
 
 const mockNotificationPrefs: NotificationPreferences = {
@@ -180,12 +180,12 @@ describe('SettingsPage', () => {
     render(<SettingsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Data Processing (Analytics)')).toBeInTheDocument()
+      expect(screen.getByText('Profile Management')).toBeInTheDocument()
     })
     expect(screen.getByRole('heading', { name: 'Data Consents' })).toBeInTheDocument()
-    expect(screen.getByText('Marketing Communications')).toBeInTheDocument()
-    expect(screen.getByText('Third-party Data Sharing')).toBeInTheDocument()
-    expect(screen.getByText('Research Participation')).toBeInTheDocument()
+    expect(screen.getByText('Emergency Contact Management')).toBeInTheDocument()
+    expect(screen.getByText('Medical Data Sharing')).toBeInTheDocument()
+    expect(screen.getByText('Medical Records Processing')).toBeInTheDocument()
   })
 
   it('renders notifications section with channel toggles', async () => {

--- a/src/components/settings/consent-constants.test.ts
+++ b/src/components/settings/consent-constants.test.ts
@@ -8,7 +8,12 @@ describe('CONSENT_ITEMS', () => {
 
   it('contains the correct purposes', () => {
     const purposes = CONSENT_ITEMS.map((item) => item.purpose)
-    expect(purposes).toEqual(['analytics', 'marketing', 'data-sharing', 'research'])
+    expect(purposes).toEqual([
+      'profile_management',
+      'emergency_contact_management',
+      'medical_data_sharing',
+      'medical_records_processing',
+    ])
   })
 
   it('has all required fields for each item', () => {

--- a/src/components/settings/consent-constants.ts
+++ b/src/components/settings/consent-constants.ts
@@ -9,27 +9,27 @@ export interface ConsentMeta {
 
 export const CONSENT_ITEMS: ConsentMeta[] = [
   {
-    purpose: 'analytics',
-    label: 'Data Processing (Analytics)',
-    description: 'Allow usage data collection to improve the app experience',
-    tooltip: 'We collect anonymous usage patterns to improve performance and identify issues. No personal health data is included.',
+    purpose: 'profile_management',
+    label: 'Profile Management',
+    description: 'Allow processing of your personal data to manage your profile',
+    tooltip: 'Required for storing and updating your name, contact details, and preferences. This is essential for your account to function.',
   },
   {
-    purpose: 'marketing',
-    label: 'Marketing Communications',
-    description: 'Receive product updates and health tips via email',
-    tooltip: 'You will receive occasional emails about new features, health tips, and promotions. You can unsubscribe at any time.',
+    purpose: 'emergency_contact_management',
+    label: 'Emergency Contact Management',
+    description: 'Allow processing of emergency contact information',
+    tooltip: 'Enables storing emergency contacts who can be notified and granted access to your records in critical situations.',
   },
   {
-    purpose: 'data-sharing',
-    label: 'Third-party Data Sharing',
-    description: 'Allow data sharing with partner healthcare services',
-    tooltip: 'Your anonymized data may be shared with verified healthcare partners to enhance service quality. Identifiable data is never shared.',
+    purpose: 'medical_data_sharing',
+    label: 'Medical Data Sharing',
+    description: 'Allow sharing medical records with your authorized doctors',
+    tooltip: 'Enables doctors you grant access to view your medical reports and health data. You control who has access and can revoke it anytime.',
   },
   {
-    purpose: 'research',
-    label: 'Research Participation',
-    description: 'Allow anonymized data for medical research studies',
-    tooltip: 'Your anonymized health data may be used in approved medical research studies. Your identity is never disclosed to researchers.',
+    purpose: 'medical_records_processing',
+    label: 'Medical Records Processing',
+    description: 'Allow processing and storage of your medical reports',
+    tooltip: 'Required for uploading, storing, and analyzing your medical reports. Reports are encrypted and only accessible to you and authorized doctors.',
   },
 ]

--- a/src/components/settings/consents-section.test.tsx
+++ b/src/components/settings/consents-section.test.tsx
@@ -16,25 +16,25 @@ function jsonResponse(data: unknown, status = 200) {
 
 const mockConsents: ConsentListResponse = [
   {
-    purpose: 'analytics',
+    purpose: 'profile_management',
     isGranted: true,
     occurredAt: '2025-06-01T00:00:00Z',
     source: 'api',
   },
   {
-    purpose: 'marketing',
+    purpose: 'emergency_contact_management',
     isGranted: false,
     occurredAt: '2025-05-15T00:00:00Z',
     source: 'api',
   },
   {
-    purpose: 'data-sharing',
+    purpose: 'medical_data_sharing',
     isGranted: true,
     occurredAt: '2025-04-20T00:00:00Z',
     source: 'api',
   },
   {
-    purpose: 'research',
+    purpose: 'medical_records_processing',
     isGranted: false,
     occurredAt: '2025-03-10T00:00:00Z',
     source: 'api',
@@ -57,11 +57,11 @@ describe('ConsentsSection', () => {
     render(<ConsentsSection />)
 
     await waitFor(() => {
-      expect(screen.getByText('Data Processing (Analytics)')).toBeInTheDocument()
+      expect(screen.getByText('Profile Management')).toBeInTheDocument()
     })
-    expect(screen.getByText('Marketing Communications')).toBeInTheDocument()
-    expect(screen.getByText('Third-party Data Sharing')).toBeInTheDocument()
-    expect(screen.getByText('Research Participation')).toBeInTheDocument()
+    expect(screen.getByText('Emergency Contact Management')).toBeInTheDocument()
+    expect(screen.getByText('Medical Data Sharing')).toBeInTheDocument()
+    expect(screen.getByText('Medical Records Processing')).toBeInTheDocument()
   })
 
   it('shows correct granted/revoked status', async () => {
@@ -69,11 +69,11 @@ describe('ConsentsSection', () => {
     render(<ConsentsSection />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('consent-status-analytics')).toHaveTextContent('Granted')
+      expect(screen.getByTestId('consent-status-profile_management')).toHaveTextContent('Granted')
     })
-    expect(screen.getByTestId('consent-status-marketing')).toHaveTextContent('Revoked')
-    expect(screen.getByTestId('consent-status-data-sharing')).toHaveTextContent('Granted')
-    expect(screen.getByTestId('consent-status-research')).toHaveTextContent('Revoked')
+    expect(screen.getByTestId('consent-status-emergency_contact_management')).toHaveTextContent('Revoked')
+    expect(screen.getByTestId('consent-status-medical_data_sharing')).toHaveTextContent('Granted')
+    expect(screen.getByTestId('consent-status-medical_records_processing')).toHaveTextContent('Revoked')
   })
 
   it('displays formatted dates', async () => {
@@ -81,7 +81,7 @@ describe('ConsentsSection', () => {
     render(<ConsentsSection />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('consent-row-analytics')).toBeInTheDocument()
+      expect(screen.getByTestId('consent-row-profile_management')).toBeInTheDocument()
     })
     const rows = screen.getAllByText(/^Updated\s/)
     expect(rows).toHaveLength(4)
@@ -92,21 +92,21 @@ describe('ConsentsSection', () => {
     render(<ConsentsSection />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('consent-switch-marketing')).toBeInTheDocument()
+      expect(screen.getByTestId('consent-switch-emergency_contact_management')).toBeInTheDocument()
     })
 
     mockFetch.mockResolvedValue(
-      jsonResponse({ purpose: 'marketing', isGranted: true, occurredAt: new Date().toISOString(), source: 'api' }),
+      jsonResponse({ purpose: 'emergency_contact_management', isGranted: true, occurredAt: new Date().toISOString(), source: 'api' }),
     )
 
-    await userEvent.click(screen.getByTestId('consent-switch-marketing'))
+    await userEvent.click(screen.getByTestId('consent-switch-emergency_contact_management'))
 
     await waitFor(() => {
       const calls = mockFetch.mock.calls
       const putCall = calls.find((call) => {
         const url = call[0] as string
         const opts = call[1] as RequestInit | undefined
-        return url.includes('/v1/consents/marketing') && opts?.method === 'PUT'
+        return url.includes('/v1/consents/emergency_contact_management') && opts?.method === 'PUT'
       })
       expect(putCall).toBeTruthy()
       const body = JSON.parse((putCall![1] as RequestInit).body as string)
@@ -119,16 +119,16 @@ describe('ConsentsSection', () => {
     render(<ConsentsSection />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('consent-switch-analytics')).toBeInTheDocument()
+      expect(screen.getByTestId('consent-switch-profile_management')).toBeInTheDocument()
     })
 
-    await userEvent.click(screen.getByTestId('consent-switch-analytics'))
+    await userEvent.click(screen.getByTestId('consent-switch-profile_management'))
 
     await waitFor(() => {
       expect(screen.getByText('Revoke Consent')).toBeInTheDocument()
     })
     expect(
-      screen.getByText(/Are you sure you want to revoke "Data Processing \(Analytics\)"/),
+      screen.getByText(/Are you sure you want to revoke "Profile Management"/),
     ).toBeInTheDocument()
   })
 
@@ -137,17 +137,17 @@ describe('ConsentsSection', () => {
     render(<ConsentsSection />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('consent-switch-analytics')).toBeInTheDocument()
+      expect(screen.getByTestId('consent-switch-profile_management')).toBeInTheDocument()
     })
 
-    await userEvent.click(screen.getByTestId('consent-switch-analytics'))
+    await userEvent.click(screen.getByTestId('consent-switch-profile_management'))
 
     await waitFor(() => {
       expect(screen.getByText('Revoke Consent')).toBeInTheDocument()
     })
 
     mockFetch.mockResolvedValue(
-      jsonResponse({ purpose: 'analytics', isGranted: false, occurredAt: new Date().toISOString(), source: 'api' }),
+      jsonResponse({ purpose: 'profile_management', isGranted: false, occurredAt: new Date().toISOString(), source: 'api' }),
     )
 
     await userEvent.click(screen.getByRole('button', { name: 'Revoke' }))
@@ -157,7 +157,7 @@ describe('ConsentsSection', () => {
       const putCall = calls.find((call) => {
         const url = call[0] as string
         const opts = call[1] as RequestInit | undefined
-        return url.includes('/v1/consents/analytics') && opts?.method === 'PUT'
+        return url.includes('/v1/consents/profile_management') && opts?.method === 'PUT'
       })
       expect(putCall).toBeTruthy()
       const body = JSON.parse((putCall![1] as RequestInit).body as string)
@@ -170,12 +170,12 @@ describe('ConsentsSection', () => {
     render(<ConsentsSection />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('consent-switch-analytics')).toBeInTheDocument()
+      expect(screen.getByTestId('consent-switch-profile_management')).toBeInTheDocument()
     })
 
     const fetchCallCountBefore = mockFetch.mock.calls.length
 
-    await userEvent.click(screen.getByTestId('consent-switch-analytics'))
+    await userEvent.click(screen.getByTestId('consent-switch-profile_management'))
 
     await waitFor(() => {
       expect(screen.getByText('Revoke Consent')).toBeInTheDocument()

--- a/src/hooks/consents/use-consents.test.tsx
+++ b/src/hooks/consents/use-consents.test.tsx
@@ -35,13 +35,13 @@ describe('useConsents', () => {
   it('fetches consents successfully', async () => {
     const data = [
       {
-        purpose: 'analytics',
+        purpose: 'profile_management',
         isGranted: true,
         occurredAt: '2025-06-01T00:00:00Z',
         source: 'api',
       },
       {
-        purpose: 'marketing',
+        purpose: 'emergency_contact_management',
         isGranted: false,
         occurredAt: '2025-05-15T00:00:00Z',
         source: 'api',

--- a/src/hooks/consents/use-update-consent.test.tsx
+++ b/src/hooks/consents/use-update-consent.test.tsx
@@ -41,7 +41,7 @@ beforeEach(() => {
 describe('useUpdateConsent', () => {
   it('sends PUT request with correct URL and body', async () => {
     const updated = {
-      purpose: 'analytics',
+      purpose: 'profile_management',
       isGranted: false,
       occurredAt: '2025-06-15T10:00:00Z',
       source: 'api',
@@ -54,7 +54,7 @@ describe('useUpdateConsent', () => {
 
     await act(() =>
       result.current.mutateAsync({
-        purpose: 'analytics',
+        purpose: 'profile_management',
         isGranted: false,
       }),
     )
@@ -62,7 +62,7 @@ describe('useUpdateConsent', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     const calledUrl = mockFetch.mock.calls[0][0] as string
-    expect(calledUrl).toContain('/v1/consents/analytics')
+    expect(calledUrl).toContain('/v1/consents/profile_management')
 
     const calledInit = mockFetch.mock.calls[0][1] as RequestInit
     expect(calledInit.method).toBe('PUT')
@@ -76,13 +76,13 @@ describe('useUpdateConsent', () => {
 
     const initialData: ConsentListResponse = [
       {
-        purpose: 'analytics',
+        purpose: 'profile_management',
         isGranted: true,
         occurredAt: '2025-06-01T00:00:00Z',
         source: 'api',
       },
       {
-        purpose: 'marketing',
+        purpose: 'emergency_contact_management',
         isGranted: false,
         occurredAt: '2025-05-15T00:00:00Z',
         source: 'api',
@@ -97,7 +97,7 @@ describe('useUpdateConsent', () => {
         resolveUpdate = () =>
           resolve(
             jsonResponse({
-              purpose: 'analytics',
+              purpose: 'profile_management',
               isGranted: false,
               occurredAt: '2025-06-15T10:00:00Z',
               source: 'api',
@@ -110,7 +110,7 @@ describe('useUpdateConsent', () => {
 
     await act(async () => {
       result.current.mutate({
-        purpose: 'analytics',
+        purpose: 'profile_management',
         isGranted: false,
       })
     })
@@ -132,7 +132,7 @@ describe('useUpdateConsent', () => {
 
     const initialData: ConsentListResponse = [
       {
-        purpose: 'analytics',
+        purpose: 'profile_management',
         isGranted: true,
         occurredAt: '2025-06-01T00:00:00Z',
         source: 'api',
@@ -149,7 +149,7 @@ describe('useUpdateConsent', () => {
 
     await act(async () => {
       result.current.mutate({
-        purpose: 'analytics',
+        purpose: 'profile_management',
         isGranted: false,
       })
     })

--- a/src/lib/schemas/consent.test.ts
+++ b/src/lib/schemas/consent.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { consentSchema } from './consent'
 
 const validData = {
-  purpose: 'analytics' as const,
+  purpose: 'profile_management' as const,
   isGranted: true,
 }
 
@@ -20,7 +20,12 @@ describe('consentSchema', () => {
     expect(result.success).toBe(true)
   })
 
-  it.each(['analytics', 'marketing', 'data-sharing', 'research'] as const)(
+  it.each([
+    'profile_management',
+    'emergency_contact_management',
+    'medical_data_sharing',
+    'medical_records_processing',
+  ] as const)(
     'accepts purpose: %s',
     (purpose) => {
       const result = consentSchema.safeParse({ ...validData, purpose })

--- a/src/lib/schemas/consent.ts
+++ b/src/lib/schemas/consent.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod/v4'
 
 export const consentSchema = z.object({
-  purpose: z.enum(['analytics', 'marketing', 'data-sharing', 'research']),
+  purpose: z.enum([
+    'profile_management',
+    'emergency_contact_management',
+    'medical_data_sharing',
+    'medical_records_processing',
+  ]),
   isGranted: z.boolean(),
 })
 

--- a/src/types/consent.ts
+++ b/src/types/consent.ts
@@ -1,4 +1,8 @@
-export type ConsentPurpose = 'analytics' | 'marketing' | 'data-sharing' | 'research'
+export type ConsentPurpose =
+  | 'profile_management'
+  | 'emergency_contact_management'
+  | 'medical_data_sharing'
+  | 'medical_records_processing'
 
 export interface Consent {
   purpose: ConsentPurpose


### PR DESCRIPTION
## Summary
- Frontend consent purposes (`analytics`, `marketing`, `data-sharing`, `research`) didn't match backend `ConsentPurposeCatalog` (`profile_management`, `emergency_contact_management`, `medical_data_sharing`, `medical_records_processing`)
- Updated `ConsentPurpose` type, Zod schema, consent constants with DPDPA-compliant labels, and all tests

## Test plan
- [x] `npm run type-check` passes
- [x] All 1343 tests pass
- [ ] Verify consent toggles work on https://dev.kinvee.in/settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)