### PR TITLE
fix(ui): resolve QA bug sweep (hydration, Aadhaar dialog, a11y, login chrome)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from 'next'
 import { DM_Serif_Display, Outfit, DM_Mono } from 'next/font/google'
 import { Providers } from './providers'
 import { AmbientOrbs } from './ambient-orbs'
-import { InstallPrompt, SwUpdateNotification } from '@/components/pwa'
+import { PwaChrome } from '@/components/pwa'
 
 const dmSerifDisplay = DM_Serif_Display({
   weight: '400',
@@ -52,8 +52,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       <body suppressHydrationWarning>
         <Providers>
           <AmbientOrbs />
-          <InstallPrompt />
-          <SwUpdateNotification />
+          <PwaChrome />
           {children}
         </Providers>
       </body>

--- a/src/components/pwa/index.ts
+++ b/src/components/pwa/index.ts
@@ -1,4 +1,5 @@
 export { InstallPrompt } from './install-prompt'
+export { PwaChrome } from './pwa-chrome'
 export { SwUpdateNotification } from './sw-update-notification'
 export { useInstallPrompt } from './use-install-prompt'
 export { useSwRegistration } from './use-sw-registration'

--- a/src/components/pwa/install-prompt.test.tsx
+++ b/src/components/pwa/install-prompt.test.tsx
@@ -114,4 +114,10 @@ describe('InstallPrompt', () => {
     const { container } = render(<InstallPrompt />)
     expect(container.textContent).toBe('')
   })
+
+  it('hides the banner when hidden even if installable', () => {
+    mockHookReturn.isInstallable = true
+    const { container } = render(<InstallPrompt hidden />)
+    expect(container.textContent).toBe('')
+  })
 })

--- a/src/components/pwa/install-prompt.tsx
+++ b/src/components/pwa/install-prompt.tsx
@@ -4,11 +4,16 @@ import { Box, Button, Text, IconButton } from '@chakra-ui/react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useInstallPrompt } from './use-install-prompt'
 
-export function InstallPrompt() {
+export interface InstallPromptProps {
+  /** Suppress the banner while keeping the beforeinstallprompt listener mounted */
+  hidden?: boolean
+}
+
+export function InstallPrompt({ hidden = false }: InstallPromptProps) {
   const { isInstallable, isStandalone, isIOS, isDismissed, promptInstall, dismiss } =
     useInstallPrompt()
 
-  const visible = (isInstallable || isIOS) && !isStandalone && !isDismissed
+  const visible = !hidden && (isInstallable || isIOS) && !isStandalone && !isDismissed
 
   return (
     <AnimatePresence>

--- a/src/components/pwa/pwa-chrome.test.tsx
+++ b/src/components/pwa/pwa-chrome.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@/test/render'
+import { PwaChrome } from './pwa-chrome'
+
+const mockNavigation = { pathname: '/reports' }
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockNavigation.pathname,
+}))
+
+vi.mock('./install-prompt', () => ({
+  InstallPrompt: ({ hidden }: { hidden?: boolean }) => (
+    <div data-testid="install-prompt" data-hidden={String(hidden)} />
+  ),
+}))
+
+vi.mock('./sw-update-notification', () => ({
+  SwUpdateNotification: ({ hidden }: { hidden?: boolean }) => (
+    <div data-testid="sw-update-notification" data-hidden={String(hidden)} />
+  ),
+}))
+
+describe('PwaChrome', () => {
+  it('shows install prompt and update notification on portal routes', () => {
+    mockNavigation.pathname = '/reports'
+    render(<PwaChrome />)
+    expect(screen.getByTestId('install-prompt')).toHaveAttribute('data-hidden', 'false')
+    expect(screen.getByTestId('sw-update-notification')).toHaveAttribute(
+      'data-hidden',
+      'false',
+    )
+  })
+
+  it.each(['/login', '/callback', '/register'])(
+    'hides the chrome on %s',
+    (pathname) => {
+      mockNavigation.pathname = pathname
+      render(<PwaChrome />)
+      expect(screen.getByTestId('install-prompt')).toHaveAttribute('data-hidden', 'true')
+      expect(screen.getByTestId('sw-update-notification')).toHaveAttribute(
+        'data-hidden',
+        'true',
+      )
+    },
+  )
+
+  it('hides the chrome on nested auth routes', () => {
+    mockNavigation.pathname = '/register/pending'
+    render(<PwaChrome />)
+    expect(screen.getByTestId('install-prompt')).toHaveAttribute('data-hidden', 'true')
+  })
+
+  it('keeps both components mounted on auth routes so listeners stay registered', () => {
+    mockNavigation.pathname = '/login'
+    render(<PwaChrome />)
+    expect(screen.getByTestId('install-prompt')).toBeInTheDocument()
+    expect(screen.getByTestId('sw-update-notification')).toBeInTheDocument()
+  })
+
+  it('does not hide the chrome on portal routes that merely share a prefix', () => {
+    mockNavigation.pathname = '/registrations-archive'
+    render(<PwaChrome />)
+    expect(screen.getByTestId('install-prompt')).toHaveAttribute('data-hidden', 'false')
+  })
+})

--- a/src/components/pwa/pwa-chrome.tsx
+++ b/src/components/pwa/pwa-chrome.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { InstallPrompt } from './install-prompt'
+import { SwUpdateNotification } from './sw-update-notification'
+
+/** Pre-sign-in routes where interruptive app chrome would clutter first impressions */
+const SUPPRESSED_ROUTES = ['/login', '/callback', '/register']
+
+export function PwaChrome() {
+  const pathname = usePathname()
+
+  // Hide the chrome on auth routes but keep both components mounted: the
+  // browser fires beforeinstallprompt only once, so the listener must be
+  // registered even while the banner is suppressed
+  const hidden = SUPPRESSED_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  )
+
+  return (
+    <>
+      <InstallPrompt hidden={hidden} />
+      <SwUpdateNotification hidden={hidden} />
+    </>
+  )
+}

--- a/src/components/pwa/sw-update-notification.test.tsx
+++ b/src/components/pwa/sw-update-notification.test.tsx
@@ -56,6 +56,12 @@ describe('SwUpdateNotification', () => {
     expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument()
   })
 
+  it('hides the toast when hidden even if an update is available', () => {
+    mockHookReturn.isUpdateAvailable = true
+    const { container } = render(<SwUpdateNotification hidden />)
+    expect(container.textContent).toBe('')
+  })
+
   it('calls applyUpdate when Update button is clicked', async () => {
     mockHookReturn.isUpdateAvailable = true
     mockHookReturn.applyUpdate = vi.fn()

--- a/src/components/pwa/sw-update-notification.tsx
+++ b/src/components/pwa/sw-update-notification.tsx
@@ -4,12 +4,17 @@ import { Box, Button, Text } from '@chakra-ui/react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useSwRegistration } from './use-sw-registration'
 
-export function SwUpdateNotification() {
+export interface SwUpdateNotificationProps {
+  /** Suppress the toast while keeping service-worker update tracking mounted */
+  hidden?: boolean
+}
+
+export function SwUpdateNotification({ hidden = false }: SwUpdateNotificationProps) {
   const { isUpdateAvailable, applyUpdate } = useSwRegistration()
 
   return (
     <AnimatePresence>
-      {isUpdateAvailable && (
+      {isUpdateAvailable && !hidden && (
         <motion.div
           initial={{ y: -60, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}

--- a/src/components/registration/consents-step.test.tsx
+++ b/src/components/registration/consents-step.test.tsx
@@ -134,9 +134,47 @@ describe('ConsentsStep', () => {
     expect(medicalConsent.isGranted).toBe(true)
   })
 
-  it('renders 4 clickable buttons', () => {
+  it('renders 4 checkboxes with accessible names', () => {
     render(<ConsentsStep consents={defaultConsents} onChange={vi.fn()} />)
-    const buttons = screen.getAllByRole('button')
-    expect(buttons).toHaveLength(4)
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(4)
+    expect(
+      screen.getByRole('checkbox', { name: 'Profile Management' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: 'Emergency Contact Management' }),
+    ).toBeInTheDocument()
+  })
+
+  it('exposes checked state via aria-checked', () => {
+    render(<ConsentsStep consents={defaultConsents} onChange={vi.fn()} />)
+    expect(
+      screen.getByRole('checkbox', { name: 'Profile Management' }),
+    ).toHaveAttribute('aria-checked', 'true')
+    expect(
+      screen.getByRole('checkbox', { name: 'Medical Data Sharing' }),
+    ).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('marks the required consent as aria-disabled', () => {
+    render(<ConsentsStep consents={defaultConsents} onChange={vi.fn()} />)
+    expect(
+      screen.getByRole('checkbox', { name: 'Profile Management' }),
+    ).toHaveAttribute('aria-disabled', 'true')
+    expect(
+      screen.getByRole('checkbox', { name: 'Medical Data Sharing' }),
+    ).toHaveAttribute('aria-disabled', 'false')
+  })
+
+  it('links each checkbox to its description via aria-describedby', () => {
+    render(<ConsentsStep consents={defaultConsents} onChange={vi.fn()} />)
+    const checkbox = screen.getByRole('checkbox', { name: 'Medical Data Sharing' })
+    expect(checkbox).toHaveAttribute(
+      'aria-describedby',
+      'consent-desc-medical_data_sharing',
+    )
+    expect(
+      document.getElementById('consent-desc-medical_data_sharing'),
+    ).toHaveTextContent(/Allow sharing your medical records/)
   })
 })

--- a/src/components/registration/consents-step.tsx
+++ b/src/components/registration/consents-step.tsx
@@ -51,6 +51,11 @@ export function ConsentsStep({ consents, onChange }: ConsentsStepProps) {
             <button
               key={item.purpose}
               type="button"
+              role="checkbox"
+              aria-checked={isGranted}
+              aria-disabled={item.required}
+              aria-label={item.label}
+              aria-describedby={`consent-desc-${item.purpose}`}
               onClick={() => toggleConsent(item.purpose)}
               style={{
                 all: 'unset',
@@ -104,7 +109,13 @@ export function ConsentsStep({ consents, onChange }: ConsentsStepProps) {
                         </Text>
                       )}
                     </Flex>
-                    <Text fontSize="xs" color="text.muted" mt="1" lineHeight="tall">
+                    <Text
+                      id={`consent-desc-${item.purpose}`}
+                      fontSize="xs"
+                      color="text.muted"
+                      mt="1"
+                      lineHeight="tall"
+                    >
                       {item.description}
                     </Text>
                   </Box>

--- a/src/components/settings/aadhaar-verify-dialog.test.tsx
+++ b/src/components/settings/aadhaar-verify-dialog.test.tsx
@@ -209,6 +209,36 @@ describe('AadhaarVerifyDialog', () => {
     })
   })
 
+  it('keeps the success view when the profile object identity changes', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(mockVerificationResponse))
+
+    const { rerender } = render(<AadhaarVerifyDialog {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('aadhaar-first-name-input')).toHaveValue('Arjun')
+    })
+
+    const aadhaarInput = screen.getByTestId('aadhaar-number-input')
+    typeAadhaarDigits(aadhaarInput, '234567890123')
+
+    await userEvent.click(screen.getByTestId('aadhaar-verify-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('aadhaar-verify-success')).toBeInTheDocument()
+    })
+
+    // Simulate the profile cache update that follows a successful verify —
+    // the success view must survive it (regression: it used to reset the mutation)
+    rerender(
+      <AadhaarVerifyDialog
+        {...defaultProps}
+        profile={{ ...mockProfile, aadhaarVerified: true }}
+      />,
+    )
+
+    expect(screen.getByTestId('aadhaar-verify-success')).toBeInTheDocument()
+  })
+
   it('calls onClose when Done is clicked in success view', async () => {
     mockFetch.mockResolvedValue(jsonResponse(mockVerificationResponse))
     const onClose = vi.fn()

--- a/src/components/settings/aadhaar-verify-dialog.tsx
+++ b/src/components/settings/aadhaar-verify-dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useRef } from 'react'
 import {
   Box,
   Button,
@@ -67,18 +67,22 @@ export function AadhaarVerifyDialog({
     resolver: zodResolver(aadhaarVerificationSchema),
   })
 
+  // Reset only when the dialog transitions to open — a successful verify updates
+  // the profile cache, and resetting on that change would wipe the success state
+  const wasOpenRef = useRef(false)
   useEffect(() => {
-    if (open) {
-      reset({
-        aadhaarNumber: '',
-        firstName: profile.firstName,
-        lastName: profile.lastName,
-        dateOfBirth: profile.dateOfBirth
-          ? formatDateForInput(profile.dateOfBirth)
-          : '',
-      })
-      resetMutation()
-    }
+    const justOpened = open && !wasOpenRef.current
+    wasOpenRef.current = open
+    if (!justOpened) return
+    reset({
+      aadhaarNumber: '',
+      firstName: profile.firstName,
+      lastName: profile.lastName,
+      dateOfBirth: profile.dateOfBirth
+        ? formatDateForInput(profile.dateOfBirth)
+        : '',
+    })
+    resetMutation()
   }, [open, profile, reset, resetMutation])
 
   const handleClose = useCallback(() => {

--- a/src/components/ui/shield-tree-loader.tsx
+++ b/src/components/ui/shield-tree-loader.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useId } from 'react'
 import { Box, Text } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
 import { useTheme } from 'next-themes'
@@ -12,9 +13,6 @@ export interface ShieldTreeLoaderProps {
 }
 
 const SIZE_MAP = { sm: 80, md: 160, lg: 240 } as const
-
-/** Unique IDs per instance to avoid SVG gradient conflicts when multiple loaders render */
-let instanceCounter = 0
 
 export function ShieldTreeLoader({
   size = 'md',
@@ -29,7 +27,9 @@ export function ShieldTreeLoader({
   const shouldShowProgress = showProgress ?? variant === 'fullPage'
   const shouldShowBrandText = showBrandText ?? variant === 'fullPage'
 
-  const id = `stl-${++instanceCounter}`
+  // useId is hydration-safe (a module counter diverges between server and client,
+  // breaking hydration); strip its delimiters, which are invalid inside url(#...)
+  const id = `stl-${useId().replace(/[^a-zA-Z0-9_-]/g, '')}`
 
   const shieldGradient = isDark
     ? { start: '#1A9E97', end: '#0E6B66' }


### PR DESCRIPTION
Fixes the four frontend bugs filed from the 2026-08-12 manual QA sweep of dev.kinvee.in, in a single commit.

## #167 — Hydration mismatch (React #418) drops first click on modals

**Root cause found:** `ShieldTreeLoader` generated its SVG gradient IDs from a module-scope counter incremented during render (`stl-${++instanceCounter}`). The server's counter grows monotonically across requests while the client restarts at 1 on every load, so the server HTML and client render disagreed on `fill="url(#stl-N-shield)"` attributes. The loader renders inside `RegistrationGate`, which wraps every portal route — hence one #418 per hard load everywhere, with React regenerating the tree and dropping the first click.

**Fix:** React's `useId()` (hydration-safe by design), sanitized for use inside `url(#...)` references. Verified: the prerendered login HTML now emits position-deterministic IDs (`stl-_R_..._-shield`).

## #168 — Aadhaar verify success screen never shows

The dialog's reset effect had `profile` in its deps; the profile cache update fired by a successful verify re-ran it, and `resetMutation()` wiped `isSuccess` before the success view could render. The effect is now edge-gated to the closed→open transition. Added a regression test that rerenders with a new profile object identity after success.

## #169 — Registration consent toggles invisible to assistive tech

The step-3 consent cards are now exposed as `role="checkbox"` with `aria-checked`, `aria-label`, `aria-disabled` (for the required consent), and `aria-describedby` linking each to its description.

## #170 — Update toast + install banner on the login screen

New `PwaChrome` wrapper renders `InstallPrompt`/`SwUpdateNotification` everywhere except the pre-sign-in routes (`/login`, `/callback`, `/register/*`).

## Verification

- 1357/1357 tests pass; coverage 95.76% statements (floor: 95.5%)
- `eslint` 0 errors, `tsc --noEmit` clean, production build succeeds
- Live-site repro + local dev/prod-build analysis confirmed the #167 root cause (login HTML previously shipped counter-based `stl-2` IDs)

Closes #167
Closes #168
Closes #169
Closes #170