### PR TITLE
fix(theme): drive SSR'd component theming with CSS instead of resolvedTheme

### DIFF
--- a/src/components/auth/shield-tree-logo.tsx
+++ b/src/components/auth/shield-tree-logo.tsx
@@ -1,30 +1,60 @@
 'use client'
 
 import { Box, Text } from '@chakra-ui/react'
-import { useTheme } from 'next-themes'
 
 export interface ShieldTreeLogoProps {
   size?: number
   showWordmark?: boolean
 }
 
+/*
+ * Theming is CSS-variable driven (light values with `_dark` overrides) instead of
+ * branching on next-themes' resolvedTheme: the server always renders light while a
+ * dark-mode client resolves dark on its first render, and any markup difference
+ * between the two breaks hydration (React #418) and drops the user's first click.
+ */
+const themeVars = {
+  '--stl-shield-start': '#0E6B66',
+  '--stl-shield-end': '#0A4D4A',
+  '--stl-canopy-start': '#A8D5AE',
+  '--stl-canopy-mid': '#7FB285',
+  '--stl-canopy-end': '#0E6B66',
+  '--stl-stroke': '#FFF8F0',
+  '--stl-highlight': 'rgba(255,255,255,0.07)',
+  '--stl-root-opacity': '0.25',
+  '--stl-branch-opacity': '0.3',
+  '--stl-canopy1-opacity': '0.45',
+  '--stl-canopy2-fill': 'rgba(127,178,133,0.4)',
+  '--stl-canopy3-fill': 'rgba(168,213,174,0.35)',
+  '--stl-canopy4-fill': 'rgba(255,255,255,0.15)',
+  '--stl-glow-opacity': '0.3',
+  _dark: {
+    '--stl-shield-start': '#1A9E97',
+    '--stl-shield-end': '#0E6B66',
+    '--stl-canopy-start': 'rgba(168,213,174,0.5)',
+    '--stl-canopy-mid': 'rgba(131,186,161,0.4)',
+    '--stl-canopy-end': 'rgba(26,158,151,0.3)',
+    '--stl-stroke': 'rgba(255,255,255,0.4)',
+    '--stl-highlight': 'rgba(255,255,255,0.04)',
+    '--stl-root-opacity': '0.15',
+    '--stl-branch-opacity': '0.2',
+    '--stl-canopy1-opacity': '0.5',
+    '--stl-canopy2-fill': 'rgba(168,213,174,0.2)',
+    '--stl-canopy3-fill': 'rgba(168,213,174,0.15)',
+    '--stl-canopy4-fill': 'rgba(255,255,255,0.08)',
+    '--stl-glow-opacity': '0.25',
+  },
+} as const
+
 export function ShieldTreeLogo({ size = 80, showWordmark = true }: ShieldTreeLogoProps) {
-  const { resolvedTheme } = useTheme()
-  const isDark = resolvedTheme === 'dark'
-
-  const shieldGradientStart = isDark ? '#1A9E97' : '#0E6B66'
-  const shieldGradientEnd = isDark ? '#0E6B66' : '#0A4D4A'
-
-  const canopyColors = isDark
-    ? { start: 'rgba(168,213,174,0.5)', end: 'rgba(26,158,151,0.3)' }
-    : { start: '#A8D5AE', mid: '#7FB285', end: '#0E6B66' }
-
-  const strokeColor = isDark ? 'rgba(255,255,255,0.4)' : '#FFF8F0'
-  const rootOpacity = isDark ? 0.15 : 0.25
-  const branchOpacity = isDark ? 0.2 : 0.3
-
   return (
-    <Box display="flex" flexDirection="column" alignItems="center" gap={3}>
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      gap={3}
+      css={themeVars}
+    >
       <svg
         width={size}
         height={size}
@@ -34,15 +64,13 @@ export function ShieldTreeLogo({ size = 80, showWordmark = true }: ShieldTreeLog
       >
         <defs>
           <linearGradient id="stl-shield" x1="20" y1="4" x2="60" y2="76" gradientUnits="userSpaceOnUse">
-            <stop offset="0%" stopColor={shieldGradientStart} />
-            <stop offset="100%" stopColor={shieldGradientEnd} />
+            <stop offset="0%" style={{ stopColor: 'var(--stl-shield-start)' }} />
+            <stop offset="100%" style={{ stopColor: 'var(--stl-shield-end)' }} />
           </linearGradient>
           <linearGradient id="stl-canopy" x1="24" y1="14" x2="56" y2="48" gradientUnits="userSpaceOnUse">
-            <stop offset="0%" stopColor={canopyColors.start} />
-            {'mid' in canopyColors && (
-              <stop offset="50%" stopColor={canopyColors.mid} />
-            )}
-            <stop offset="100%" stopColor={canopyColors.end} />
+            <stop offset="0%" style={{ stopColor: 'var(--stl-canopy-start)' }} />
+            <stop offset="50%" style={{ stopColor: 'var(--stl-canopy-mid)' }} />
+            <stop offset="100%" style={{ stopColor: 'var(--stl-canopy-end)' }} />
           </linearGradient>
         </defs>
 
@@ -55,38 +83,42 @@ export function ShieldTreeLogo({ size = 80, showWordmark = true }: ShieldTreeLog
         {/* Shield inner highlight */}
         <path
           d="M40 10 C26 10 16 14 16 14 L16 36 C16 52 27 64 40 70 C53 64 64 52 64 36 L64 14 C64 14 54 10 40 10Z"
-          fill={isDark ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.07)'}
+          style={{ fill: 'var(--stl-highlight)' }}
         />
 
         {/* Trunk */}
         <path
           d="M40 66 L40 44"
-          stroke={strokeColor}
+          style={{ stroke: 'var(--stl-stroke)' }}
           strokeWidth={3}
           strokeLinecap="round"
           opacity={0.5}
         />
 
         {/* Roots */}
-        <path d="M40 66 C36 68 30 69 28 68" stroke={strokeColor} strokeWidth={1.2} strokeLinecap="round" opacity={rootOpacity} />
-        <path d="M40 66 C44 68 50 69 52 68" stroke={strokeColor} strokeWidth={1.2} strokeLinecap="round" opacity={rootOpacity} />
-        <path d="M40 66 C38 69 36 71 34 71" stroke={strokeColor} strokeWidth={1} strokeLinecap="round" opacity={rootOpacity * 0.8} />
-        <path d="M40 66 C42 69 44 71 46 71" stroke={strokeColor} strokeWidth={1} strokeLinecap="round" opacity={rootOpacity * 0.8} />
+        <g style={{ opacity: 'var(--stl-root-opacity)' }}>
+          <path d="M40 66 C36 68 30 69 28 68" style={{ stroke: 'var(--stl-stroke)' }} strokeWidth={1.2} strokeLinecap="round" />
+          <path d="M40 66 C44 68 50 69 52 68" style={{ stroke: 'var(--stl-stroke)' }} strokeWidth={1.2} strokeLinecap="round" />
+          <path d="M40 66 C38 69 36 71 34 71" style={{ stroke: 'var(--stl-stroke)' }} strokeWidth={1} strokeLinecap="round" opacity={0.8} />
+          <path d="M40 66 C42 69 44 71 46 71" style={{ stroke: 'var(--stl-stroke)' }} strokeWidth={1} strokeLinecap="round" opacity={0.8} />
+        </g>
 
         {/* Branches */}
-        <path d="M40 48 C34 44 28 42 24 42" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" opacity={branchOpacity} />
-        <path d="M40 48 C46 44 52 42 56 42" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" opacity={branchOpacity} />
-        <path d="M40 44 C36 40 32 36 30 34" stroke={strokeColor} strokeWidth={1.2} strokeLinecap="round" opacity={branchOpacity * 0.85} />
-        <path d="M40 44 C44 40 48 36 50 34" stroke={strokeColor} strokeWidth={1.2} strokeLinecap="round" opacity={branchOpacity * 0.85} />
+        <g style={{ opacity: 'var(--stl-branch-opacity)' }}>
+          <path d="M40 48 C34 44 28 42 24 42" style={{ stroke: 'var(--stl-stroke)' }} strokeWidth={1.5} strokeLinecap="round" />
+          <path d="M40 48 C46 44 52 42 56 42" style={{ stroke: 'var(--stl-stroke)' }} strokeWidth={1.5} strokeLinecap="round" />
+          <path d="M40 44 C36 40 32 36 30 34" style={{ stroke: 'var(--stl-stroke)' }} strokeWidth={1.2} strokeLinecap="round" opacity={0.85} />
+          <path d="M40 44 C44 40 48 36 50 34" style={{ stroke: 'var(--stl-stroke)' }} strokeWidth={1.2} strokeLinecap="round" opacity={0.85} />
+        </g>
 
         {/* Canopy layers */}
-        <ellipse cx={40} cy={36} rx={22} ry={16} fill="url(#stl-canopy)" opacity={isDark ? 0.5 : 0.45} />
-        <ellipse cx={40} cy={32} rx={17} ry={13} fill={isDark ? 'rgba(168,213,174,0.2)' : '#7FB285'} opacity={isDark ? 1 : 0.4} />
-        <ellipse cx={40} cy={27} rx={12} ry={10} fill={isDark ? 'rgba(168,213,174,0.15)' : '#A8D5AE'} opacity={isDark ? 1 : 0.35} />
-        <ellipse cx={40} cy={22} rx={7} ry={6} fill={isDark ? 'rgba(255,255,255,0.08)' : 'rgba(255,255,255,0.15)'} />
+        <ellipse cx={40} cy={36} rx={22} ry={16} fill="url(#stl-canopy)" style={{ opacity: 'var(--stl-canopy1-opacity)' }} />
+        <ellipse cx={40} cy={32} rx={17} ry={13} style={{ fill: 'var(--stl-canopy2-fill)' }} />
+        <ellipse cx={40} cy={27} rx={12} ry={10} style={{ fill: 'var(--stl-canopy3-fill)' }} />
+        <ellipse cx={40} cy={22} rx={7} ry={6} style={{ fill: 'var(--stl-canopy4-fill)' }} />
 
         {/* Ground glow */}
-        <ellipse cx={40} cy={68} rx={12} ry={2.5} fill="#FFB347" opacity={isDark ? 0.25 : 0.3} />
+        <ellipse cx={40} cy={68} rx={12} ry={2.5} fill="#FFB347" style={{ opacity: 'var(--stl-glow-opacity)' }} />
       </svg>
 
       {showWordmark && (

--- a/src/components/portal/top-bar.test.tsx
+++ b/src/components/portal/top-bar.test.tsx
@@ -23,7 +23,7 @@ describe('TopBar', () => {
 
   it('renders the color mode toggle', () => {
     render(<TopBar onMenuToggle={vi.fn()} />)
-    expect(screen.getByRole('button', { name: /switch to dark mode/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /toggle color mode/i })).toBeInTheDocument()
   })
 
   it('renders the mobile menu toggle button', () => {

--- a/src/components/ui/color-mode-toggle.test.tsx
+++ b/src/components/ui/color-mode-toggle.test.tsx
@@ -19,9 +19,14 @@ describe('ColorModeToggle', () => {
     mockResolvedTheme = 'light'
   })
 
-  it('renders with "switch to dark mode" label in light mode', () => {
+  it('renders with a theme-independent label', () => {
     render(<ColorModeToggle />)
-    expect(screen.getByRole('button', { name: /switch to dark mode/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /toggle color mode/i })).toBeInTheDocument()
+  })
+
+  it('renders both icons so CSS can select one without markup changes', () => {
+    const { container } = render(<ColorModeToggle />)
+    expect(container.querySelectorAll('svg')).toHaveLength(2)
   })
 
   it('toggles to dark mode on click in light mode', async () => {
@@ -30,12 +35,6 @@ describe('ColorModeToggle', () => {
 
     await user.click(screen.getByRole('button'))
     expect(mockSetTheme).toHaveBeenCalledWith('dark')
-  })
-
-  it('renders with "switch to light mode" label in dark mode', () => {
-    mockResolvedTheme = 'dark'
-    render(<ColorModeToggle />)
-    expect(screen.getByRole('button', { name: /switch to light mode/i })).toBeInTheDocument()
   })
 
   it('toggles to light mode on click in dark mode', async () => {

--- a/src/components/ui/color-mode-toggle.tsx
+++ b/src/components/ui/color-mode-toggle.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { IconButton } from '@chakra-ui/react'
+import { Box, IconButton } from '@chakra-ui/react'
 import { useTheme } from 'next-themes'
 
 function SunIcon() {
@@ -51,19 +51,25 @@ function MoonIcon() {
 
 export function ColorModeToggle() {
   const { resolvedTheme, setTheme } = useTheme()
-  const isDark = resolvedTheme === 'dark'
 
+  // Render both icons and let CSS pick one — branching the markup on resolvedTheme
+  // breaks hydration for dark-mode users (server renders light, client resolves dark)
   return (
     <IconButton
-      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      aria-label="Toggle color mode"
+      onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
       variant="ghost"
       borderRadius="full"
       size="sm"
       color="text.secondary"
       _hover={{ bg: 'bg.overlay' }}
     >
-      {isDark ? <SunIcon /> : <MoonIcon />}
+      <Box display={{ base: 'inline-flex', _dark: 'none' }} aria-hidden="true">
+        <MoonIcon />
+      </Box>
+      <Box display={{ base: 'none', _dark: 'inline-flex' }} aria-hidden="true">
+        <SunIcon />
+      </Box>
     </IconButton>
   )
 }

--- a/src/components/ui/shield-tree-loader.tsx
+++ b/src/components/ui/shield-tree-loader.tsx
@@ -3,7 +3,6 @@
 import { useId } from 'react'
 import { Box, Text } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
-import { useTheme } from 'next-themes'
 
 export interface ShieldTreeLoaderProps {
   size?: 'sm' | 'md' | 'lg'
@@ -14,14 +13,55 @@ export interface ShieldTreeLoaderProps {
 
 const SIZE_MAP = { sm: 80, md: 160, lg: 240 } as const
 
+/*
+ * Theming is CSS-variable driven (light values with `_dark` overrides) instead of
+ * branching on next-themes' resolvedTheme: the server always renders light while a
+ * dark-mode client resolves dark on its first render, and any markup difference
+ * between the two breaks hydration (React #418). Framer-motion animation targets
+ * stay theme-independent; the themed factor lives in group opacities and fill alphas.
+ */
+const themeVars = {
+  '--stl-shield-start': '#0E6B66',
+  '--stl-shield-end': '#0A4D4A',
+  '--stl-shield-stroke': '#0E6B66',
+  '--stl-canopy-start': '#A8D5AE',
+  '--stl-canopy-mid': '#7FB285',
+  '--stl-canopy-end': '#0E6B66',
+  '--stl-stroke': '#FFF8F0',
+  '--stl-root-opacity': '0.3',
+  '--stl-branch-opacity': '0.35',
+  '--stl-canopy2-fill': 'rgba(127,178,133,0.4)',
+  '--stl-canopy3-fill': 'rgba(168,213,174,0.35)',
+  '--stl-canopy4-fill': 'rgba(255,255,255,0.3)',
+  _dark: {
+    '--stl-shield-start': '#1A9E97',
+    '--stl-shield-end': '#0E6B66',
+    '--stl-shield-stroke': '#1A9E97',
+    '--stl-canopy-start': 'rgba(168,213,174,0.5)',
+    '--stl-canopy-mid': 'rgba(131,186,161,0.4)',
+    '--stl-canopy-end': 'rgba(26,158,151,0.3)',
+    '--stl-stroke': 'rgba(255,255,255,0.4)',
+    '--stl-root-opacity': '0.15',
+    '--stl-branch-opacity': '0.2',
+    '--stl-canopy2-fill': 'rgba(168,213,174,0.2)',
+    '--stl-canopy3-fill': 'rgba(168,213,174,0.15)',
+    '--stl-canopy4-fill': 'rgba(255,255,255,0.08)',
+  },
+} as const
+
+const RIPPLE_COLORS = [
+  null,
+  { base: '#0E6B66', _dark: '#1A9E97' },
+  { base: '#7FB285', _dark: '#A8D5AE' },
+  { base: '#FFB347', _dark: '#FFD693' },
+] as const
+
 export function ShieldTreeLoader({
   size = 'md',
   variant = 'inline',
   showProgress,
   showBrandText,
 }: ShieldTreeLoaderProps) {
-  const { resolvedTheme } = useTheme()
-  const isDark = resolvedTheme === 'dark'
   const px = SIZE_MAP[size]
 
   const shouldShowProgress = showProgress ?? variant === 'fullPage'
@@ -31,19 +71,6 @@ export function ShieldTreeLoader({
   // breaking hydration); strip its delimiters, which are invalid inside url(#...)
   const id = `stl-${useId().replace(/[^a-zA-Z0-9_-]/g, '')}`
 
-  const shieldGradient = isDark
-    ? { start: '#1A9E97', end: '#0E6B66' }
-    : { start: '#0E6B66', end: '#0A4D4A' }
-
-  const canopyGradient = isDark
-    ? { start: 'rgba(168,213,174,0.5)', end: 'rgba(26,158,151,0.3)' }
-    : { start: '#A8D5AE', mid: '#7FB285', end: '#0E6B66' }
-
-  const strokeColor = isDark ? 'rgba(255,255,255,0.4)' : '#FFF8F0'
-  const rootOpacity = isDark ? 0.15 : 0.3
-  const branchOpacity = isDark ? 0.2 : 0.35
-  const shieldStroke = isDark ? '#1A9E97' : '#0E6B66'
-
   const content = (
     <Box
       display="flex"
@@ -52,6 +79,7 @@ export function ShieldTreeLoader({
       justifyContent="center"
       role="status"
       aria-label="Loading"
+      css={themeVars}
     >
       {/* Tree animation container */}
       <Box position="relative" width={`${px}px`} height={`${px}px`}>
@@ -67,11 +95,7 @@ export function ShieldTreeLoader({
             borderRadius="full"
             borderStyle="solid"
             borderWidth="1.5px"
-            borderColor={
-              isDark
-                ? ['', '#1A9E97', '#A8D5AE', '#FFD693'][i]
-                : ['', '#0E6B66', '#7FB285', '#FFB347'][i]
-            }
+            borderColor={RIPPLE_COLORS[i] ?? undefined}
             opacity={0}
             pointerEvents="none"
             css={{
@@ -103,8 +127,8 @@ export function ShieldTreeLoader({
               y2="76"
               gradientUnits="userSpaceOnUse"
             >
-              <stop offset="0%" stopColor={shieldGradient.start} />
-              <stop offset="100%" stopColor={shieldGradient.end} />
+              <stop offset="0%" style={{ stopColor: 'var(--stl-shield-start)' }} />
+              <stop offset="100%" style={{ stopColor: 'var(--stl-shield-end)' }} />
             </linearGradient>
             <linearGradient
               id={`${id}-canopy`}
@@ -114,11 +138,9 @@ export function ShieldTreeLoader({
               y2="48"
               gradientUnits="userSpaceOnUse"
             >
-              <stop offset="0%" stopColor={canopyGradient.start} />
-              {'mid' in canopyGradient && (
-                <stop offset="50%" stopColor={canopyGradient.mid} />
-              )}
-              <stop offset="100%" stopColor={canopyGradient.end} />
+              <stop offset="0%" style={{ stopColor: 'var(--stl-canopy-start)' }} />
+              <stop offset="50%" style={{ stopColor: 'var(--stl-canopy-mid)' }} />
+              <stop offset="100%" style={{ stopColor: 'var(--stl-canopy-end)' }} />
             </linearGradient>
           </defs>
 
@@ -126,7 +148,7 @@ export function ShieldTreeLoader({
           <motion.path
             d="M40 4 C22 4 10 10 10 10 L10 36 C10 56 24 70 40 76 C56 70 70 56 70 36 L70 10 C70 10 58 4 40 4Z"
             fill={`url(#${id}-shield)`}
-            stroke={shieldStroke}
+            style={{ stroke: 'var(--stl-shield-stroke)' }}
             strokeWidth={1}
             initial={{ strokeDasharray: 300, strokeDashoffset: 300, fillOpacity: 0 }}
             animate={{ strokeDashoffset: 0, fillOpacity: 0.9 }}
@@ -158,7 +180,7 @@ export function ShieldTreeLoader({
           {/* Trunk */}
           <motion.path
             d="M40 66 L40 44"
-            stroke={strokeColor}
+            style={{ stroke: 'var(--stl-stroke)' }}
             strokeWidth={3}
             strokeLinecap="round"
             initial={{ strokeDasharray: 40, strokeDashoffset: 40, opacity: 0 }}
@@ -166,8 +188,8 @@ export function ShieldTreeLoader({
             transition={{ delay: 1.8, duration: 1.0, ease: 'easeOut' }}
           />
 
-          {/* Roots */}
-          <g data-testid="roots">
+          {/* Roots — the group carries the themed opacity; paths animate to fixed targets */}
+          <g data-testid="roots" style={{ opacity: 'var(--stl-root-opacity)' }}>
             {[
               'M40 66 C36 68 30 69 28 68',
               'M40 66 C44 68 50 69 52 68',
@@ -177,18 +199,18 @@ export function ShieldTreeLoader({
               <motion.path
                 key={d}
                 d={d}
-                stroke={strokeColor}
+                style={{ stroke: 'var(--stl-stroke)' }}
                 strokeWidth={i < 2 ? 1.2 : 1}
                 strokeLinecap="round"
                 initial={{ strokeDasharray: 30, strokeDashoffset: 30, opacity: 0 }}
-                animate={{ strokeDashoffset: 0, opacity: rootOpacity }}
+                animate={{ strokeDashoffset: 0, opacity: i < 2 ? 1 : 0.8 }}
                 transition={{ delay: 2.0 + i * 0.1, duration: 0.8, ease: 'easeOut' }}
               />
             ))}
           </g>
 
           {/* Branches */}
-          <g data-testid="branches">
+          <g data-testid="branches" style={{ opacity: 'var(--stl-branch-opacity)' }}>
             {[
               'M40 48 C34 44 28 42 24 42',
               'M40 48 C46 44 52 42 56 42',
@@ -198,11 +220,11 @@ export function ShieldTreeLoader({
               <motion.path
                 key={d}
                 d={d}
-                stroke={strokeColor}
+                style={{ stroke: 'var(--stl-stroke)' }}
                 strokeWidth={i < 2 ? 1.5 : 1.2}
                 strokeLinecap="round"
                 initial={{ strokeDasharray: 30, strokeDashoffset: 30, opacity: 0 }}
-                animate={{ strokeDashoffset: 0, opacity: branchOpacity }}
+                animate={{ strokeDashoffset: 0, opacity: i < 2 ? 1 : 0.85 }}
                 transition={{ delay: 2.4 + i * 0.1, duration: 0.7, ease: 'easeOut' }}
               />
             ))}
@@ -211,10 +233,10 @@ export function ShieldTreeLoader({
           {/* Canopy */}
           <g data-testid="canopy">
             {[
-              { cx: 40, cy: 36, rx: 22, ry: 16, fill: `url(#${id}-canopy)`, opacity: isDark ? 0.5 : 0.45 },
-              { cx: 40, cy: 32, rx: 17, ry: 13, fill: isDark ? 'rgba(168,213,174,0.2)' : '#7FB285', opacity: isDark ? 1 : 0.4 },
-              { cx: 40, cy: 27, rx: 12, ry: 10, fill: isDark ? 'rgba(168,213,174,0.15)' : '#A8D5AE', opacity: isDark ? 1 : 0.35 },
-              { cx: 40, cy: 22, rx: 7, ry: 6, fill: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(255,255,255,0.3)', opacity: 1 },
+              { cx: 40, cy: 36, rx: 22, ry: 16, fill: `url(#${id}-canopy)`, target: 0.5 },
+              { cx: 40, cy: 32, rx: 17, ry: 13, fillVar: '--stl-canopy2-fill', target: 1 },
+              { cx: 40, cy: 27, rx: 12, ry: 10, fillVar: '--stl-canopy3-fill', target: 1 },
+              { cx: 40, cy: 22, rx: 7, ry: 6, fillVar: '--stl-canopy4-fill', target: 1 },
             ].map((e, i) => (
               <motion.ellipse
                 key={i}
@@ -223,8 +245,9 @@ export function ShieldTreeLoader({
                 rx={e.rx}
                 ry={e.ry}
                 fill={e.fill}
+                style={e.fillVar ? { fill: `var(${e.fillVar})` } : undefined}
                 initial={{ opacity: 0, scale: 0.2 }}
-                animate={{ opacity: e.opacity, scale: 1 }}
+                animate={{ opacity: e.target, scale: 1 }}
                 transition={{
                   delay: 2.8 + i * 0.2,
                   duration: 0.8,
@@ -292,7 +315,7 @@ export function ShieldTreeLoader({
             height="3px"
             borderRadius="full"
             overflow="hidden"
-            bg={isDark ? 'rgba(255,255,255,0.08)' : 'rgba(10,77,74,0.1)'}
+            bg={{ base: 'rgba(10,77,74,0.1)', _dark: 'rgba(255,255,255,0.08)' }}
           >
             <Box
               height="100%"


### PR DESCRIPTION
Second (and actual primary) root cause of #167's React #418.

## What was happening

`ShieldTreeLogo`, `ShieldTreeLoader`, and `ColorModeToggle` branch their rendered markup on next-themes' `resolvedTheme`. The server always renders the light variant; a dark-mode client resolves `dark` synchronously on its first render. For dark-mode users this mismatched SVG gradient colors, a conditional third gradient stop (structural), the moon/sun icon, and its aria-label — on **every** route that server-renders one of these components: login/callback (logo), and every portal route (registration-gate loader + top-bar toggle). React threw #418, regenerated the tree, and dropped the first click.

Reproduced deterministically in dev mode with `theme=dark` — full hydration diff pointed at `ShieldTreeLogo`'s gradient stops (`#1A9E97` client vs `#0E6B66` server). The earlier useId fix (#171) was real but secondary; light-mode users were why it looked fixed.

## The fix

Theme via CSS, not JS: all themed colors/opacities move to CSS custom properties with `_dark` overrides. The `.dark` class is on `<html>` before hydration (next-themes inline script), so CSS resolves the right palette with **identical markup** server- and client-side.

- Canopy gradient normalized to 3 stops in both themes
- Framer-motion animation targets are now theme-independent; themed factors live in group opacities and fill alphas (visual parity with the old values)
- `ColorModeToggle` renders both icons, CSS picks one; static "Toggle color mode" aria-label; handler reads `resolvedTheme` only at click time

## Verification

- Dev-mode dark-theme load of /login: hydration error gone (was 100% reproducible before); computed gradient stop = `rgb(26,158,151)` (dark palette via CSS var)
- 1364/1364 tests pass, coverage 95.74% (floor 95.5%), lint/type-check clean

Re-fixes #167 for dark-mode users.